### PR TITLE
Added build of individual componenets for Ryzen 9 5950x

### DIFF
--- a/ryzen-9-5950x-128gb-docker-zeus-individual-components-nvme/8-build-individual-components.16.chromium-x11.log
+++ b/ryzen-9-5950x-128gb-docker-zeus-individual-components-nvme/8-build-individual-components.16.chromium-x11.log
@@ -1,0 +1,35 @@
+Loading cache...done.
+Loaded 2448 entries from dependency cache.
+NOTE: Resolving any missing task queue dependencies
+
+Build Configuration:
+BB_VERSION           = "1.44.0"
+BUILD_SYS            = "x86_64-linux"
+NATIVELSBSTRING      = "universal"
+TARGET_SYS           = "x86_64-poky-linux"
+MACHINE              = "qemux86-64"
+DISTRO               = "poky"
+DISTRO_VERSION       = "3.0.2"
+TUNE_FEATURES        = "m64 core2"
+TARGET_FPU           = ""
+meta                 
+meta-poky            
+meta-yocto-bsp       = "zeus:341f87a6ba32f900c744c26d026c5aad6e19c09d"
+meta-browser         = "zeus:1697014a05967ed54b294f3c4b5621df494d6551"
+meta-rust            = "zeus:5d1ada0c97723e1526bf5599b2fa2cbb56c2c0dc"
+meta-oe              = "zeus:e855ecc6d35677e79780adc57b2552213c995731"
+meta-clang           = "zeus:0c393398a91713a108f319ac75337c02b7ebeaa7"
+meta-qt5             = "zeus:a582fd4c810529e9af0c81700407b1955d1391d2"
+
+Initialising tasks...done.
+Sstate summary: Wanted 0 Found 0 Missed 0 Current 232 (0% match, 100% complete)
+NOTE: Executing Tasks
+NOTE: Setscene tasks completed
+NOTE: Running task 1912 of 1913 (/home/yocto/oe-test/test-oe-build-time/poky/meta-browser/recipes-browser/chromium/chromium-x11_79.0.3945.117.bb:do_add_nodejs_symlink)
+NOTE: recipe chromium-x11-79.0.3945.117-r0: task do_add_nodejs_symlink: Started
+NOTE: recipe chromium-x11-79.0.3945.117-r0: task do_add_nodejs_symlink: Succeeded
+NOTE: Running task 1913 of 1913 (/home/yocto/oe-test/test-oe-build-time/poky/meta-browser/recipes-browser/chromium/chromium-x11_79.0.3945.117.bb:do_compile)
+NOTE: recipe chromium-x11-79.0.3945.117-r0: task do_compile: Started
+NOTE: recipe chromium-x11-79.0.3945.117-r0: task do_compile: Succeeded
+NOTE: Tasks Summary: Attempted 1913 tasks of which 1911 didn't need to be rerun and all succeeded.
+TIME: 4024.90 0.87 9.13 0% 668 145466 9357 0 27896 0 bitbake -c compile chromium-x11

--- a/ryzen-9-5950x-128gb-docker-zeus-individual-components-nvme/8-build-individual-components.16.qtbase.log
+++ b/ryzen-9-5950x-128gb-docker-zeus-individual-components-nvme/8-build-individual-components.16.qtbase.log
@@ -1,0 +1,35 @@
+Loading cache...done.
+Loaded 2448 entries from dependency cache.
+NOTE: Resolving any missing task queue dependencies
+
+Build Configuration:
+BB_VERSION           = "1.44.0"
+BUILD_SYS            = "x86_64-linux"
+NATIVELSBSTRING      = "universal"
+TARGET_SYS           = "x86_64-poky-linux"
+MACHINE              = "qemux86-64"
+DISTRO               = "poky"
+DISTRO_VERSION       = "3.0.2"
+TUNE_FEATURES        = "m64 core2"
+TARGET_FPU           = ""
+meta                 
+meta-poky            
+meta-yocto-bsp       = "zeus:341f87a6ba32f900c744c26d026c5aad6e19c09d"
+meta-browser         = "zeus:1697014a05967ed54b294f3c4b5621df494d6551"
+meta-rust            = "zeus:5d1ada0c97723e1526bf5599b2fa2cbb56c2c0dc"
+meta-oe              = "zeus:e855ecc6d35677e79780adc57b2552213c995731"
+meta-clang           = "zeus:0c393398a91713a108f319ac75337c02b7ebeaa7"
+meta-qt5             = "zeus:a582fd4c810529e9af0c81700407b1955d1391d2"
+
+Initialising tasks...done.
+Sstate summary: Wanted 0 Found 0 Missed 0 Current 138 (0% match, 100% complete)
+NOTE: Executing Tasks
+NOTE: Setscene tasks completed
+NOTE: Running task 1131 of 1132 (/home/yocto/oe-test/test-oe-build-time/poky/meta-qt5/recipes-qt/qt5/qtbase_git.bb:do_configure_ptest_base)
+NOTE: recipe qtbase-5.13.2+gitAUTOINC+a7a24784ee-r0: task do_configure_ptest_base: Started
+NOTE: recipe qtbase-5.13.2+gitAUTOINC+a7a24784ee-r0: task do_configure_ptest_base: Succeeded
+NOTE: Running task 1132 of 1132 (/home/yocto/oe-test/test-oe-build-time/poky/meta-qt5/recipes-qt/qt5/qtbase_git.bb:do_compile)
+NOTE: recipe qtbase-5.13.2+gitAUTOINC+a7a24784ee-r0: task do_compile: Started
+NOTE: recipe qtbase-5.13.2+gitAUTOINC+a7a24784ee-r0: task do_compile: Succeeded
+NOTE: Tasks Summary: Attempted 1132 tasks of which 1130 didn't need to be rerun and all succeeded.
+TIME: 464.23 0.04 0.38 0% 9 13854 9370 0 27900 0 bitbake -c compile qtbase

--- a/ryzen-9-5950x-128gb-docker-zeus-individual-components-nvme/8-build-individual-components.16.qtdeclarative.log
+++ b/ryzen-9-5950x-128gb-docker-zeus-individual-components-nvme/8-build-individual-components.16.qtdeclarative.log
@@ -1,0 +1,35 @@
+Loading cache...done.
+Loaded 2448 entries from dependency cache.
+NOTE: Resolving any missing task queue dependencies
+
+Build Configuration:
+BB_VERSION           = "1.44.0"
+BUILD_SYS            = "x86_64-linux"
+NATIVELSBSTRING      = "universal"
+TARGET_SYS           = "x86_64-poky-linux"
+MACHINE              = "qemux86-64"
+DISTRO               = "poky"
+DISTRO_VERSION       = "3.0.2"
+TUNE_FEATURES        = "m64 core2"
+TARGET_FPU           = ""
+meta                 
+meta-poky            
+meta-yocto-bsp       = "zeus:341f87a6ba32f900c744c26d026c5aad6e19c09d"
+meta-browser         = "zeus:1697014a05967ed54b294f3c4b5621df494d6551"
+meta-rust            = "zeus:5d1ada0c97723e1526bf5599b2fa2cbb56c2c0dc"
+meta-oe              = "zeus:e855ecc6d35677e79780adc57b2552213c995731"
+meta-clang           = "zeus:0c393398a91713a108f319ac75337c02b7ebeaa7"
+meta-qt5             = "zeus:a582fd4c810529e9af0c81700407b1955d1391d2"
+
+Initialising tasks...done.
+Sstate summary: Wanted 0 Found 0 Missed 0 Current 139 (0% match, 100% complete)
+NOTE: Executing Tasks
+NOTE: Setscene tasks completed
+NOTE: Running task 1143 of 1144 (/home/yocto/oe-test/test-oe-build-time/poky/meta-qt5/recipes-qt/qt5/qtdeclarative_git.bb:do_configure_ptest_base)
+NOTE: recipe qtdeclarative-5.13.2+gitAUTOINC+4080025fed-r0: task do_configure_ptest_base: Started
+NOTE: recipe qtdeclarative-5.13.2+gitAUTOINC+4080025fed-r0: task do_configure_ptest_base: Succeeded
+NOTE: Running task 1144 of 1144 (/home/yocto/oe-test/test-oe-build-time/poky/meta-qt5/recipes-qt/qt5/qtdeclarative_git.bb:do_compile)
+NOTE: recipe qtdeclarative-5.13.2+gitAUTOINC+4080025fed-r0: task do_compile: Started
+NOTE: recipe qtdeclarative-5.13.2+gitAUTOINC+4080025fed-r0: task do_compile: Succeeded
+NOTE: Tasks Summary: Attempted 1144 tasks of which 1142 didn't need to be rerun and all succeeded.
+TIME: 194.39 0.04 0.29 0% 6 11759 9366 0 27904 0 bitbake -c compile qtdeclarative

--- a/ryzen-9-5950x-128gb-docker-zeus-individual-components-nvme/8-build-individual-components.16.qtwebengine.log
+++ b/ryzen-9-5950x-128gb-docker-zeus-individual-components-nvme/8-build-individual-components.16.qtwebengine.log
@@ -1,0 +1,32 @@
+Loading cache...done.
+Loaded 2448 entries from dependency cache.
+NOTE: Resolving any missing task queue dependencies
+
+Build Configuration:
+BB_VERSION           = "1.44.0"
+BUILD_SYS            = "x86_64-linux"
+NATIVELSBSTRING      = "universal"
+TARGET_SYS           = "x86_64-poky-linux"
+MACHINE              = "qemux86-64"
+DISTRO               = "poky"
+DISTRO_VERSION       = "3.0.2"
+TUNE_FEATURES        = "m64 core2"
+TARGET_FPU           = ""
+meta                 
+meta-poky            
+meta-yocto-bsp       = "zeus:341f87a6ba32f900c744c26d026c5aad6e19c09d"
+meta-browser         = "zeus:1697014a05967ed54b294f3c4b5621df494d6551"
+meta-rust            = "zeus:5d1ada0c97723e1526bf5599b2fa2cbb56c2c0dc"
+meta-oe              = "zeus:e855ecc6d35677e79780adc57b2552213c995731"
+meta-clang           = "zeus:0c393398a91713a108f319ac75337c02b7ebeaa7"
+meta-qt5             = "zeus:a582fd4c810529e9af0c81700407b1955d1391d2"
+
+Initialising tasks...done.
+Sstate summary: Wanted 0 Found 0 Missed 0 Current 195 (0% match, 100% complete)
+NOTE: Executing Tasks
+NOTE: Setscene tasks completed
+NOTE: Running task 1619 of 1619 (/home/yocto/oe-test/test-oe-build-time/poky/meta-qt5/recipes-qt/qt5/qtwebengine_git.bb:do_compile)
+NOTE: recipe qtwebengine-5.13.2+gitAUTOINC+556576b55f_843d70ac87-r0: task do_compile: Started
+NOTE: recipe qtwebengine-5.13.2+gitAUTOINC+556576b55f_843d70ac87-r0: task do_compile: Succeeded
+NOTE: Tasks Summary: Attempted 1619 tasks of which 1618 didn't need to be rerun and all succeeded.
+TIME: 1346.32 0.30 3.44 0% 94 65844 9364 0 27764 0 bitbake -c compile qtwebengine

--- a/ryzen-9-5950x-128gb-docker-zeus-individual-components-nvme/8-build-individual-components.16.rust-native.log
+++ b/ryzen-9-5950x-128gb-docker-zeus-individual-components-nvme/8-build-individual-components.16.rust-native.log
@@ -1,0 +1,35 @@
+Loading cache...done.
+Loaded 2448 entries from dependency cache.
+NOTE: Resolving any missing task queue dependencies
+
+Build Configuration:
+BB_VERSION           = "1.44.0"
+BUILD_SYS            = "x86_64-linux"
+NATIVELSBSTRING      = "universal"
+TARGET_SYS           = "x86_64-poky-linux"
+MACHINE              = "qemux86-64"
+DISTRO               = "poky"
+DISTRO_VERSION       = "3.0.2"
+TUNE_FEATURES        = "m64 core2"
+TARGET_FPU           = ""
+meta                 
+meta-poky            
+meta-yocto-bsp       = "zeus:341f87a6ba32f900c744c26d026c5aad6e19c09d"
+meta-browser         = "zeus:1697014a05967ed54b294f3c4b5621df494d6551"
+meta-rust            = "zeus:5d1ada0c97723e1526bf5599b2fa2cbb56c2c0dc"
+meta-oe              = "zeus:e855ecc6d35677e79780adc57b2552213c995731"
+meta-clang           = "zeus:0c393398a91713a108f319ac75337c02b7ebeaa7"
+meta-qt5             = "zeus:a582fd4c810529e9af0c81700407b1955d1391d2"
+
+Initialising tasks...done.
+Sstate summary: Wanted 0 Found 0 Missed 0 Current 25 (0% match, 100% complete)
+NOTE: Executing Tasks
+NOTE: Setscene tasks completed
+NOTE: Running task 166 of 210 (virtual:native:/home/yocto/oe-test/test-oe-build-time/poky/meta-rust/recipes-devtools/rust/rust_1.37.0.bb:do_rust_gen_targets)
+NOTE: recipe rust-native-1.37.0-r0: task do_rust_gen_targets: Started
+NOTE: recipe rust-native-1.37.0-r0: task do_rust_gen_targets: Succeeded
+NOTE: Running task 210 of 210 (virtual:native:/home/yocto/oe-test/test-oe-build-time/poky/meta-rust/recipes-devtools/rust/rust_1.37.0.bb:do_compile)
+NOTE: recipe rust-native-1.37.0-r0: task do_compile: Started
+NOTE: recipe rust-native-1.37.0-r0: task do_compile: Succeeded
+NOTE: Tasks Summary: Attempted 210 tasks of which 208 didn't need to be rerun and all succeeded.
+TIME: 1124.71 0.04 0.41 0% 13 12639 9372 0 27984 0 bitbake -c compile rust-native

--- a/ryzen-9-5950x-128gb-docker-zeus-individual-components-nvme/8-build-individual-components.24.chromium-x11.log
+++ b/ryzen-9-5950x-128gb-docker-zeus-individual-components-nvme/8-build-individual-components.24.chromium-x11.log
@@ -1,0 +1,35 @@
+Loading cache...done.
+Loaded 2448 entries from dependency cache.
+NOTE: Resolving any missing task queue dependencies
+
+Build Configuration:
+BB_VERSION           = "1.44.0"
+BUILD_SYS            = "x86_64-linux"
+NATIVELSBSTRING      = "universal"
+TARGET_SYS           = "x86_64-poky-linux"
+MACHINE              = "qemux86-64"
+DISTRO               = "poky"
+DISTRO_VERSION       = "3.0.2"
+TUNE_FEATURES        = "m64 core2"
+TARGET_FPU           = ""
+meta                 
+meta-poky            
+meta-yocto-bsp       = "zeus:341f87a6ba32f900c744c26d026c5aad6e19c09d"
+meta-browser         = "zeus:1697014a05967ed54b294f3c4b5621df494d6551"
+meta-rust            = "zeus:5d1ada0c97723e1526bf5599b2fa2cbb56c2c0dc"
+meta-oe              = "zeus:e855ecc6d35677e79780adc57b2552213c995731"
+meta-clang           = "zeus:0c393398a91713a108f319ac75337c02b7ebeaa7"
+meta-qt5             = "zeus:a582fd4c810529e9af0c81700407b1955d1391d2"
+
+Initialising tasks...done.
+Sstate summary: Wanted 0 Found 0 Missed 0 Current 232 (0% match, 100% complete)
+NOTE: Executing Tasks
+NOTE: Setscene tasks completed
+NOTE: Running task 1912 of 1913 (/home/yocto/oe-test/test-oe-build-time/poky/meta-browser/recipes-browser/chromium/chromium-x11_79.0.3945.117.bb:do_add_nodejs_symlink)
+NOTE: recipe chromium-x11-79.0.3945.117-r0: task do_add_nodejs_symlink: Started
+NOTE: recipe chromium-x11-79.0.3945.117-r0: task do_add_nodejs_symlink: Succeeded
+NOTE: Running task 1913 of 1913 (/home/yocto/oe-test/test-oe-build-time/poky/meta-browser/recipes-browser/chromium/chromium-x11_79.0.3945.117.bb:do_compile)
+NOTE: recipe chromium-x11-79.0.3945.117-r0: task do_compile: Started
+NOTE: recipe chromium-x11-79.0.3945.117-r0: task do_compile: Succeeded
+NOTE: Tasks Summary: Attempted 1913 tasks of which 1911 didn't need to be rerun and all succeeded.
+TIME: 3587.78 0.86 9.71 0% 576 140699 9368 0 27816 0 bitbake -c compile chromium-x11

--- a/ryzen-9-5950x-128gb-docker-zeus-individual-components-nvme/8-build-individual-components.24.qtbase.log
+++ b/ryzen-9-5950x-128gb-docker-zeus-individual-components-nvme/8-build-individual-components.24.qtbase.log
@@ -1,0 +1,35 @@
+Loading cache...done.
+Loaded 2448 entries from dependency cache.
+NOTE: Resolving any missing task queue dependencies
+
+Build Configuration:
+BB_VERSION           = "1.44.0"
+BUILD_SYS            = "x86_64-linux"
+NATIVELSBSTRING      = "universal"
+TARGET_SYS           = "x86_64-poky-linux"
+MACHINE              = "qemux86-64"
+DISTRO               = "poky"
+DISTRO_VERSION       = "3.0.2"
+TUNE_FEATURES        = "m64 core2"
+TARGET_FPU           = ""
+meta                 
+meta-poky            
+meta-yocto-bsp       = "zeus:341f87a6ba32f900c744c26d026c5aad6e19c09d"
+meta-browser         = "zeus:1697014a05967ed54b294f3c4b5621df494d6551"
+meta-rust            = "zeus:5d1ada0c97723e1526bf5599b2fa2cbb56c2c0dc"
+meta-oe              = "zeus:e855ecc6d35677e79780adc57b2552213c995731"
+meta-clang           = "zeus:0c393398a91713a108f319ac75337c02b7ebeaa7"
+meta-qt5             = "zeus:a582fd4c810529e9af0c81700407b1955d1391d2"
+
+Initialising tasks...done.
+Sstate summary: Wanted 0 Found 0 Missed 0 Current 138 (0% match, 100% complete)
+NOTE: Executing Tasks
+NOTE: Setscene tasks completed
+NOTE: Running task 1131 of 1132 (/home/yocto/oe-test/test-oe-build-time/poky/meta-qt5/recipes-qt/qt5/qtbase_git.bb:do_configure_ptest_base)
+NOTE: recipe qtbase-5.13.2+gitAUTOINC+a7a24784ee-r0: task do_configure_ptest_base: Started
+NOTE: recipe qtbase-5.13.2+gitAUTOINC+a7a24784ee-r0: task do_configure_ptest_base: Succeeded
+NOTE: Running task 1132 of 1132 (/home/yocto/oe-test/test-oe-build-time/poky/meta-qt5/recipes-qt/qt5/qtbase_git.bb:do_compile)
+NOTE: recipe qtbase-5.13.2+gitAUTOINC+a7a24784ee-r0: task do_compile: Started
+NOTE: recipe qtbase-5.13.2+gitAUTOINC+a7a24784ee-r0: task do_compile: Succeeded
+NOTE: Tasks Summary: Attempted 1132 tasks of which 1130 didn't need to be rerun and all succeeded.
+TIME: 436.29 0.04 0.35 0% 8 12718 9363 0 27820 0 bitbake -c compile qtbase

--- a/ryzen-9-5950x-128gb-docker-zeus-individual-components-nvme/8-build-individual-components.24.qtdeclarative.log
+++ b/ryzen-9-5950x-128gb-docker-zeus-individual-components-nvme/8-build-individual-components.24.qtdeclarative.log
@@ -1,0 +1,35 @@
+Loading cache...done.
+Loaded 2448 entries from dependency cache.
+NOTE: Resolving any missing task queue dependencies
+
+Build Configuration:
+BB_VERSION           = "1.44.0"
+BUILD_SYS            = "x86_64-linux"
+NATIVELSBSTRING      = "universal"
+TARGET_SYS           = "x86_64-poky-linux"
+MACHINE              = "qemux86-64"
+DISTRO               = "poky"
+DISTRO_VERSION       = "3.0.2"
+TUNE_FEATURES        = "m64 core2"
+TARGET_FPU           = ""
+meta                 
+meta-poky            
+meta-yocto-bsp       = "zeus:341f87a6ba32f900c744c26d026c5aad6e19c09d"
+meta-browser         = "zeus:1697014a05967ed54b294f3c4b5621df494d6551"
+meta-rust            = "zeus:5d1ada0c97723e1526bf5599b2fa2cbb56c2c0dc"
+meta-oe              = "zeus:e855ecc6d35677e79780adc57b2552213c995731"
+meta-clang           = "zeus:0c393398a91713a108f319ac75337c02b7ebeaa7"
+meta-qt5             = "zeus:a582fd4c810529e9af0c81700407b1955d1391d2"
+
+Initialising tasks...done.
+Sstate summary: Wanted 0 Found 0 Missed 0 Current 139 (0% match, 100% complete)
+NOTE: Executing Tasks
+NOTE: Setscene tasks completed
+NOTE: Running task 1143 of 1144 (/home/yocto/oe-test/test-oe-build-time/poky/meta-qt5/recipes-qt/qt5/qtdeclarative_git.bb:do_configure_ptest_base)
+NOTE: recipe qtdeclarative-5.13.2+gitAUTOINC+4080025fed-r0: task do_configure_ptest_base: Started
+NOTE: recipe qtdeclarative-5.13.2+gitAUTOINC+4080025fed-r0: task do_configure_ptest_base: Succeeded
+NOTE: Running task 1144 of 1144 (/home/yocto/oe-test/test-oe-build-time/poky/meta-qt5/recipes-qt/qt5/qtdeclarative_git.bb:do_compile)
+NOTE: recipe qtdeclarative-5.13.2+gitAUTOINC+4080025fed-r0: task do_compile: Started
+NOTE: recipe qtdeclarative-5.13.2+gitAUTOINC+4080025fed-r0: task do_compile: Succeeded
+NOTE: Tasks Summary: Attempted 1144 tasks of which 1142 didn't need to be rerun and all succeeded.
+TIME: 177.52 0.03 0.26 0% 8 12796 9356 0 27780 0 bitbake -c compile qtdeclarative

--- a/ryzen-9-5950x-128gb-docker-zeus-individual-components-nvme/8-build-individual-components.24.qtwebengine.log
+++ b/ryzen-9-5950x-128gb-docker-zeus-individual-components-nvme/8-build-individual-components.24.qtwebengine.log
@@ -1,0 +1,32 @@
+Loading cache...done.
+Loaded 2448 entries from dependency cache.
+NOTE: Resolving any missing task queue dependencies
+
+Build Configuration:
+BB_VERSION           = "1.44.0"
+BUILD_SYS            = "x86_64-linux"
+NATIVELSBSTRING      = "universal"
+TARGET_SYS           = "x86_64-poky-linux"
+MACHINE              = "qemux86-64"
+DISTRO               = "poky"
+DISTRO_VERSION       = "3.0.2"
+TUNE_FEATURES        = "m64 core2"
+TARGET_FPU           = ""
+meta                 
+meta-poky            
+meta-yocto-bsp       = "zeus:341f87a6ba32f900c744c26d026c5aad6e19c09d"
+meta-browser         = "zeus:1697014a05967ed54b294f3c4b5621df494d6551"
+meta-rust            = "zeus:5d1ada0c97723e1526bf5599b2fa2cbb56c2c0dc"
+meta-oe              = "zeus:e855ecc6d35677e79780adc57b2552213c995731"
+meta-clang           = "zeus:0c393398a91713a108f319ac75337c02b7ebeaa7"
+meta-qt5             = "zeus:a582fd4c810529e9af0c81700407b1955d1391d2"
+
+Initialising tasks...done.
+Sstate summary: Wanted 0 Found 0 Missed 0 Current 195 (0% match, 100% complete)
+NOTE: Executing Tasks
+NOTE: Setscene tasks completed
+NOTE: Running task 1619 of 1619 (/home/yocto/oe-test/test-oe-build-time/poky/meta-qt5/recipes-qt/qt5/qtwebengine_git.bb:do_compile)
+NOTE: recipe qtwebengine-5.13.2+gitAUTOINC+556576b55f_843d70ac87-r0: task do_compile: Started
+NOTE: recipe qtwebengine-5.13.2+gitAUTOINC+556576b55f_843d70ac87-r0: task do_compile: Succeeded
+NOTE: Tasks Summary: Attempted 1619 tasks of which 1618 didn't need to be rerun and all succeeded.
+TIME: 1162.39 0.36 3.43 0% 167 63144 9360 0 27572 0 bitbake -c compile qtwebengine

--- a/ryzen-9-5950x-128gb-docker-zeus-individual-components-nvme/8-build-individual-components.24.rust-native.log
+++ b/ryzen-9-5950x-128gb-docker-zeus-individual-components-nvme/8-build-individual-components.24.rust-native.log
@@ -1,0 +1,35 @@
+Loading cache...done.
+Loaded 2448 entries from dependency cache.
+NOTE: Resolving any missing task queue dependencies
+
+Build Configuration:
+BB_VERSION           = "1.44.0"
+BUILD_SYS            = "x86_64-linux"
+NATIVELSBSTRING      = "universal"
+TARGET_SYS           = "x86_64-poky-linux"
+MACHINE              = "qemux86-64"
+DISTRO               = "poky"
+DISTRO_VERSION       = "3.0.2"
+TUNE_FEATURES        = "m64 core2"
+TARGET_FPU           = ""
+meta                 
+meta-poky            
+meta-yocto-bsp       = "zeus:341f87a6ba32f900c744c26d026c5aad6e19c09d"
+meta-browser         = "zeus:1697014a05967ed54b294f3c4b5621df494d6551"
+meta-rust            = "zeus:5d1ada0c97723e1526bf5599b2fa2cbb56c2c0dc"
+meta-oe              = "zeus:e855ecc6d35677e79780adc57b2552213c995731"
+meta-clang           = "zeus:0c393398a91713a108f319ac75337c02b7ebeaa7"
+meta-qt5             = "zeus:a582fd4c810529e9af0c81700407b1955d1391d2"
+
+Initialising tasks...done.
+Sstate summary: Wanted 0 Found 0 Missed 0 Current 25 (0% match, 100% complete)
+NOTE: Executing Tasks
+NOTE: Setscene tasks completed
+NOTE: Running task 166 of 210 (virtual:native:/home/yocto/oe-test/test-oe-build-time/poky/meta-rust/recipes-devtools/rust/rust_1.37.0.bb:do_rust_gen_targets)
+NOTE: recipe rust-native-1.37.0-r0: task do_rust_gen_targets: Started
+NOTE: recipe rust-native-1.37.0-r0: task do_rust_gen_targets: Succeeded
+NOTE: Running task 210 of 210 (virtual:native:/home/yocto/oe-test/test-oe-build-time/poky/meta-rust/recipes-devtools/rust/rust_1.37.0.bb:do_compile)
+NOTE: recipe rust-native-1.37.0-r0: task do_compile: Started
+NOTE: recipe rust-native-1.37.0-r0: task do_compile: Succeeded
+NOTE: Tasks Summary: Attempted 210 tasks of which 208 didn't need to be rerun and all succeeded.
+TIME: 1131.57 0.02 0.42 0% 22 12886 9359 0 27840 0 bitbake -c compile rust-native

--- a/ryzen-9-5950x-128gb-docker-zeus-individual-components-nvme/8-build-individual-components.32.chromium-x11.log
+++ b/ryzen-9-5950x-128gb-docker-zeus-individual-components-nvme/8-build-individual-components.32.chromium-x11.log
@@ -1,0 +1,35 @@
+Loading cache...done.
+Loaded 2448 entries from dependency cache.
+NOTE: Resolving any missing task queue dependencies
+
+Build Configuration:
+BB_VERSION           = "1.44.0"
+BUILD_SYS            = "x86_64-linux"
+NATIVELSBSTRING      = "universal"
+TARGET_SYS           = "x86_64-poky-linux"
+MACHINE              = "qemux86-64"
+DISTRO               = "poky"
+DISTRO_VERSION       = "3.0.2"
+TUNE_FEATURES        = "m64 core2"
+TARGET_FPU           = ""
+meta                 
+meta-poky            
+meta-yocto-bsp       = "zeus:341f87a6ba32f900c744c26d026c5aad6e19c09d"
+meta-browser         = "zeus:1697014a05967ed54b294f3c4b5621df494d6551"
+meta-rust            = "zeus:5d1ada0c97723e1526bf5599b2fa2cbb56c2c0dc"
+meta-oe              = "zeus:e855ecc6d35677e79780adc57b2552213c995731"
+meta-clang           = "zeus:0c393398a91713a108f319ac75337c02b7ebeaa7"
+meta-qt5             = "zeus:a582fd4c810529e9af0c81700407b1955d1391d2"
+
+Initialising tasks...done.
+Sstate summary: Wanted 0 Found 0 Missed 0 Current 232 (0% match, 100% complete)
+NOTE: Executing Tasks
+NOTE: Setscene tasks completed
+NOTE: Running task 1912 of 1913 (/home/yocto/oe-test/test-oe-build-time/poky/meta-browser/recipes-browser/chromium/chromium-x11_79.0.3945.117.bb:do_add_nodejs_symlink)
+NOTE: recipe chromium-x11-79.0.3945.117-r0: task do_add_nodejs_symlink: Started
+NOTE: recipe chromium-x11-79.0.3945.117-r0: task do_add_nodejs_symlink: Succeeded
+NOTE: Running task 1913 of 1913 (/home/yocto/oe-test/test-oe-build-time/poky/meta-browser/recipes-browser/chromium/chromium-x11_79.0.3945.117.bb:do_compile)
+NOTE: recipe chromium-x11-79.0.3945.117-r0: task do_compile: Started
+NOTE: recipe chromium-x11-79.0.3945.117-r0: task do_compile: Succeeded
+NOTE: Tasks Summary: Attempted 1913 tasks of which 1911 didn't need to be rerun and all succeeded.
+TIME: 3420.56 0.87 10.12 0% 753 105969 9363 0 27836 0 bitbake -c compile chromium-x11

--- a/ryzen-9-5950x-128gb-docker-zeus-individual-components-nvme/8-build-individual-components.32.qtbase.log
+++ b/ryzen-9-5950x-128gb-docker-zeus-individual-components-nvme/8-build-individual-components.32.qtbase.log
@@ -1,0 +1,35 @@
+Loading cache...done.
+Loaded 2448 entries from dependency cache.
+NOTE: Resolving any missing task queue dependencies
+
+Build Configuration:
+BB_VERSION           = "1.44.0"
+BUILD_SYS            = "x86_64-linux"
+NATIVELSBSTRING      = "universal"
+TARGET_SYS           = "x86_64-poky-linux"
+MACHINE              = "qemux86-64"
+DISTRO               = "poky"
+DISTRO_VERSION       = "3.0.2"
+TUNE_FEATURES        = "m64 core2"
+TARGET_FPU           = ""
+meta                 
+meta-poky            
+meta-yocto-bsp       = "zeus:341f87a6ba32f900c744c26d026c5aad6e19c09d"
+meta-browser         = "zeus:1697014a05967ed54b294f3c4b5621df494d6551"
+meta-rust            = "zeus:5d1ada0c97723e1526bf5599b2fa2cbb56c2c0dc"
+meta-oe              = "zeus:e855ecc6d35677e79780adc57b2552213c995731"
+meta-clang           = "zeus:0c393398a91713a108f319ac75337c02b7ebeaa7"
+meta-qt5             = "zeus:a582fd4c810529e9af0c81700407b1955d1391d2"
+
+Initialising tasks...done.
+Sstate summary: Wanted 0 Found 0 Missed 0 Current 138 (0% match, 100% complete)
+NOTE: Executing Tasks
+NOTE: Setscene tasks completed
+NOTE: Running task 1131 of 1132 (/home/yocto/oe-test/test-oe-build-time/poky/meta-qt5/recipes-qt/qt5/qtbase_git.bb:do_configure_ptest_base)
+NOTE: recipe qtbase-5.13.2+gitAUTOINC+a7a24784ee-r0: task do_configure_ptest_base: Started
+NOTE: recipe qtbase-5.13.2+gitAUTOINC+a7a24784ee-r0: task do_configure_ptest_base: Succeeded
+NOTE: Running task 1132 of 1132 (/home/yocto/oe-test/test-oe-build-time/poky/meta-qt5/recipes-qt/qt5/qtbase_git.bb:do_compile)
+NOTE: recipe qtbase-5.13.2+gitAUTOINC+a7a24784ee-r0: task do_compile: Started
+NOTE: recipe qtbase-5.13.2+gitAUTOINC+a7a24784ee-r0: task do_compile: Succeeded
+NOTE: Tasks Summary: Attempted 1132 tasks of which 1130 didn't need to be rerun and all succeeded.
+TIME: 423.59 0.03 0.34 0% 25 13780 9364 0 27960 0 bitbake -c compile qtbase

--- a/ryzen-9-5950x-128gb-docker-zeus-individual-components-nvme/8-build-individual-components.32.qtdeclarative.log
+++ b/ryzen-9-5950x-128gb-docker-zeus-individual-components-nvme/8-build-individual-components.32.qtdeclarative.log
@@ -1,0 +1,35 @@
+Loading cache...done.
+Loaded 2448 entries from dependency cache.
+NOTE: Resolving any missing task queue dependencies
+
+Build Configuration:
+BB_VERSION           = "1.44.0"
+BUILD_SYS            = "x86_64-linux"
+NATIVELSBSTRING      = "universal"
+TARGET_SYS           = "x86_64-poky-linux"
+MACHINE              = "qemux86-64"
+DISTRO               = "poky"
+DISTRO_VERSION       = "3.0.2"
+TUNE_FEATURES        = "m64 core2"
+TARGET_FPU           = ""
+meta                 
+meta-poky            
+meta-yocto-bsp       = "zeus:341f87a6ba32f900c744c26d026c5aad6e19c09d"
+meta-browser         = "zeus:1697014a05967ed54b294f3c4b5621df494d6551"
+meta-rust            = "zeus:5d1ada0c97723e1526bf5599b2fa2cbb56c2c0dc"
+meta-oe              = "zeus:e855ecc6d35677e79780adc57b2552213c995731"
+meta-clang           = "zeus:0c393398a91713a108f319ac75337c02b7ebeaa7"
+meta-qt5             = "zeus:a582fd4c810529e9af0c81700407b1955d1391d2"
+
+Initialising tasks...done.
+Sstate summary: Wanted 0 Found 0 Missed 0 Current 139 (0% match, 100% complete)
+NOTE: Executing Tasks
+NOTE: Setscene tasks completed
+NOTE: Running task 1143 of 1144 (/home/yocto/oe-test/test-oe-build-time/poky/meta-qt5/recipes-qt/qt5/qtdeclarative_git.bb:do_configure_ptest_base)
+NOTE: recipe qtdeclarative-5.13.2+gitAUTOINC+4080025fed-r0: task do_configure_ptest_base: Started
+NOTE: recipe qtdeclarative-5.13.2+gitAUTOINC+4080025fed-r0: task do_configure_ptest_base: Succeeded
+NOTE: Running task 1144 of 1144 (/home/yocto/oe-test/test-oe-build-time/poky/meta-qt5/recipes-qt/qt5/qtdeclarative_git.bb:do_compile)
+NOTE: recipe qtdeclarative-5.13.2+gitAUTOINC+4080025fed-r0: task do_compile: Started
+NOTE: recipe qtdeclarative-5.13.2+gitAUTOINC+4080025fed-r0: task do_compile: Succeeded
+NOTE: Tasks Summary: Attempted 1144 tasks of which 1142 didn't need to be rerun and all succeeded.
+TIME: 168.77 0.02 0.26 0% 5 12794 9362 0 27952 0 bitbake -c compile qtdeclarative

--- a/ryzen-9-5950x-128gb-docker-zeus-individual-components-nvme/8-build-individual-components.32.qtwebengine.log
+++ b/ryzen-9-5950x-128gb-docker-zeus-individual-components-nvme/8-build-individual-components.32.qtwebengine.log
@@ -1,0 +1,32 @@
+Loading cache...done.
+Loaded 2448 entries from dependency cache.
+NOTE: Resolving any missing task queue dependencies
+
+Build Configuration:
+BB_VERSION           = "1.44.0"
+BUILD_SYS            = "x86_64-linux"
+NATIVELSBSTRING      = "universal"
+TARGET_SYS           = "x86_64-poky-linux"
+MACHINE              = "qemux86-64"
+DISTRO               = "poky"
+DISTRO_VERSION       = "3.0.2"
+TUNE_FEATURES        = "m64 core2"
+TARGET_FPU           = ""
+meta                 
+meta-poky            
+meta-yocto-bsp       = "zeus:341f87a6ba32f900c744c26d026c5aad6e19c09d"
+meta-browser         = "zeus:1697014a05967ed54b294f3c4b5621df494d6551"
+meta-rust            = "zeus:5d1ada0c97723e1526bf5599b2fa2cbb56c2c0dc"
+meta-oe              = "zeus:e855ecc6d35677e79780adc57b2552213c995731"
+meta-clang           = "zeus:0c393398a91713a108f319ac75337c02b7ebeaa7"
+meta-qt5             = "zeus:a582fd4c810529e9af0c81700407b1955d1391d2"
+
+Initialising tasks...done.
+Sstate summary: Wanted 0 Found 0 Missed 0 Current 195 (0% match, 100% complete)
+NOTE: Executing Tasks
+NOTE: Setscene tasks completed
+NOTE: Running task 1619 of 1619 (/home/yocto/oe-test/test-oe-build-time/poky/meta-qt5/recipes-qt/qt5/qtwebengine_git.bb:do_compile)
+NOTE: recipe qtwebengine-5.13.2+gitAUTOINC+556576b55f_843d70ac87-r0: task do_compile: Started
+NOTE: recipe qtwebengine-5.13.2+gitAUTOINC+556576b55f_843d70ac87-r0: task do_compile: Succeeded
+NOTE: Tasks Summary: Attempted 1619 tasks of which 1618 didn't need to be rerun and all succeeded.
+TIME: 1155.13 0.31 3.46 0% 572 49766 9357 0 27996 0 bitbake -c compile qtwebengine

--- a/ryzen-9-5950x-128gb-docker-zeus-individual-components-nvme/8-build-individual-components.32.rust-native.log
+++ b/ryzen-9-5950x-128gb-docker-zeus-individual-components-nvme/8-build-individual-components.32.rust-native.log
@@ -1,0 +1,35 @@
+Loading cache...done.
+Loaded 2448 entries from dependency cache.
+NOTE: Resolving any missing task queue dependencies
+
+Build Configuration:
+BB_VERSION           = "1.44.0"
+BUILD_SYS            = "x86_64-linux"
+NATIVELSBSTRING      = "universal"
+TARGET_SYS           = "x86_64-poky-linux"
+MACHINE              = "qemux86-64"
+DISTRO               = "poky"
+DISTRO_VERSION       = "3.0.2"
+TUNE_FEATURES        = "m64 core2"
+TARGET_FPU           = ""
+meta                 
+meta-poky            
+meta-yocto-bsp       = "zeus:341f87a6ba32f900c744c26d026c5aad6e19c09d"
+meta-browser         = "zeus:1697014a05967ed54b294f3c4b5621df494d6551"
+meta-rust            = "zeus:5d1ada0c97723e1526bf5599b2fa2cbb56c2c0dc"
+meta-oe              = "zeus:e855ecc6d35677e79780adc57b2552213c995731"
+meta-clang           = "zeus:0c393398a91713a108f319ac75337c02b7ebeaa7"
+meta-qt5             = "zeus:a582fd4c810529e9af0c81700407b1955d1391d2"
+
+Initialising tasks...done.
+Sstate summary: Wanted 0 Found 0 Missed 0 Current 25 (0% match, 100% complete)
+NOTE: Executing Tasks
+NOTE: Setscene tasks completed
+NOTE: Running task 166 of 210 (virtual:native:/home/yocto/oe-test/test-oe-build-time/poky/meta-rust/recipes-devtools/rust/rust_1.37.0.bb:do_rust_gen_targets)
+NOTE: recipe rust-native-1.37.0-r0: task do_rust_gen_targets: Started
+NOTE: recipe rust-native-1.37.0-r0: task do_rust_gen_targets: Succeeded
+NOTE: Running task 210 of 210 (virtual:native:/home/yocto/oe-test/test-oe-build-time/poky/meta-rust/recipes-devtools/rust/rust_1.37.0.bb:do_compile)
+NOTE: recipe rust-native-1.37.0-r0: task do_compile: Started
+NOTE: recipe rust-native-1.37.0-r0: task do_compile: Succeeded
+NOTE: Tasks Summary: Attempted 210 tasks of which 208 didn't need to be rerun and all succeeded.
+TIME: 1162.33 0.02 0.44 0% 7 13010 9364 0 27908 0 bitbake -c compile rust-native

--- a/ryzen-9-5950x-128gb-docker-zeus-individual-components-nvme/lshw.txt
+++ b/ryzen-9-5950x-128gb-docker-zeus-individual-components-nvme/lshw.txt
@@ -1,0 +1,945 @@
+nova
+    description: Desktop Computer
+    product: System Product Name (SKU)
+    vendor: ASUS
+    version: System Version
+    serial: System Serial Number
+    width: 4294967295 bits
+    capabilities: smbios-3.3 dmi-3.3 smp vsyscall32
+    configuration: boot=normal chassis=desktop family=To be filled by O.E.M. sku=SKU uuid=C3589B36-244B-FE52-CB06-244BFE52CB05
+  *-core
+       description: Motherboard
+       product: ROG CROSSHAIR VIII HERO
+       vendor: ASUSTeK COMPUTER INC.
+       physical id: 0
+       version: Rev X.0x
+       serial: 200670636500635
+       slot: Default string
+     *-firmware
+          description: BIOS
+          vendor: American Megatrends Inc.
+          physical id: 0
+          version: 3204
+          date: 01/25/2021
+          size: 64KiB
+          capacity: 15MiB
+          capabilities: pci apm upgrade shadowing cdboot bootselect socketedrom edd int13floppy1200 int13floppy720 int13floppy2880 int5printscreen int9keyboard int14serial int17printer acpi usb biosbootspecification uefi
+     *-memory
+          description: System Memory
+          physical id: 3a
+          slot: System board or motherboard
+          size: 128GiB
+        *-bank:0
+             description: DIMM DDR4 Synchronous Unbuffered (Unregistered) 3600 MHz (0,3 ns)
+             product: BL32G36C16U4B.M16FB1
+             vendor: Crucial Technology
+             physical id: 0
+             serial: E3958BA2
+             slot: DIMM_A1
+             size: 32GiB
+             width: 64 bits
+             clock: 3600MHz (0.3ns)
+        *-bank:1
+             description: DIMM DDR4 Synchronous Unbuffered (Unregistered) 3600 MHz (0,3 ns)
+             product: BL32G36C16U4B.M16FB1
+             vendor: Crucial Technology
+             physical id: 1
+             serial: E3958AE8
+             slot: DIMM_A2
+             size: 32GiB
+             width: 64 bits
+             clock: 3600MHz (0.3ns)
+        *-bank:2
+             description: DIMM DDR4 Synchronous Unbuffered (Unregistered) 3600 MHz (0,3 ns)
+             product: BL32G36C16U4B.M16FB1
+             vendor: Crucial Technology
+             physical id: 2
+             serial: E3958D79
+             slot: DIMM_B1
+             size: 32GiB
+             width: 64 bits
+             clock: 3600MHz (0.3ns)
+        *-bank:3
+             description: DIMM DDR4 Synchronous Unbuffered (Unregistered) 3600 MHz (0,3 ns)
+             product: BL32G36C16U4B.M16FB1
+             vendor: Crucial Technology
+             physical id: 3
+             serial: E3958CAA
+             slot: DIMM_B2
+             size: 32GiB
+             width: 64 bits
+             clock: 3600MHz (0.3ns)
+     *-cache:0
+          description: L1 cache
+          physical id: 3d
+          slot: L1 - Cache
+          size: 1MiB
+          capacity: 1MiB
+          clock: 1GHz (1.0ns)
+          capabilities: pipeline-burst internal write-back unified
+          configuration: level=1
+     *-cache:1
+          description: L2 cache
+          physical id: 3e
+          slot: L2 - Cache
+          size: 8MiB
+          capacity: 8MiB
+          clock: 1GHz (1.0ns)
+          capabilities: pipeline-burst internal write-back unified
+          configuration: level=2
+     *-cache:2
+          description: L3 cache
+          physical id: 3f
+          slot: L3 - Cache
+          size: 64MiB
+          capacity: 64MiB
+          clock: 1GHz (1.0ns)
+          capabilities: pipeline-burst internal write-back unified
+          configuration: level=3
+     *-cpu
+          description: CPU
+          product: AMD Ryzen 9 5950X 16-Core Processor
+          vendor: Advanced Micro Devices [AMD]
+          physical id: 40
+          bus info: cpu@0
+          version: AMD Ryzen 9 5950X 16-Core Processor
+          serial: Unknown
+          slot: AM4
+          size: 4640MHz
+          width: 64 bits
+          clock: 100MHz
+          capabilities: x86-64 fpu fpu_exception wp vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp constant_tsc rep_good nopl nonstop_tsc cpuid extd_apicid aperfmperf pni pclmulqdq monitor ssse3 fma cx16 sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand lahf_lm cmp_legacy svm extapic cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw ibs skinit wdt tce topoext perfctr_core perfctr_nb bpext perfctr_llc mwaitx cpb cat_l3 cdp_l3 hw_pstate ssbd mba ibrs ibpb stibp vmmcall fsgsbase bmi1 avx2 smep bmi2 erms invpcid cqm rdt_a rdseed adx smap clflushopt clwb sha_ni xsaveopt xsavec xgetbv1 xsaves cqm_llc cqm_occup_llc cqm_mbm_total cqm_mbm_local clzero irperf xsaveerptr rdpru wbnoinvd arat npt lbrv svm_lock nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold avic v_vmsave_vmload vgif umip pku ospke vaes vpclmulqdq rdpid overflow_recov succor smca fsrm cpufreq
+          configuration: cores=16 enabledcores=16 threads=32
+     *-pci:0
+          description: Host bridge
+          product: Starship/Matisse Root Complex
+          vendor: Advanced Micro Devices, Inc. [AMD]
+          physical id: 100
+          bus info: pci@0000:00:00.0
+          version: 00
+          width: 32 bits
+          clock: 33MHz
+        *-generic UNCLAIMED
+             description: IOMMU
+             product: Starship/Matisse IOMMU
+             vendor: Advanced Micro Devices, Inc. [AMD]
+             physical id: 0.2
+             bus info: pci@0000:00:00.2
+             version: 00
+             width: 32 bits
+             clock: 33MHz
+             capabilities: msi ht cap_list
+             configuration: latency=0
+        *-pci:0
+             description: PCI bridge
+             product: Starship/Matisse GPP Bridge
+             vendor: Advanced Micro Devices, Inc. [AMD]
+             physical id: 1.1
+             bus info: pci@0000:00:01.1
+             version: 00
+             width: 32 bits
+             clock: 33MHz
+             capabilities: pci pm pciexpress msi ht normal_decode bus_master cap_list
+             configuration: driver=pcieport
+             resources: irq:27 memory:fcf00000-fcffffff
+           *-storage
+                description: Non-Volatile memory controller
+                product: E16 PCIe4 NVMe Controller
+                vendor: Phison Electronics Corporation
+                physical id: 0
+                bus info: pci@0000:01:00.0
+                version: 01
+                width: 64 bits
+                clock: 33MHz
+                capabilities: storage pciexpress msix msi pm nvm_express bus_master cap_list
+                configuration: driver=nvme latency=0
+                resources: irq:42 memory:fcf00000-fcf03fff
+        *-pci:1
+             description: PCI bridge
+             product: Starship/Matisse GPP Bridge
+             vendor: Advanced Micro Devices, Inc. [AMD]
+             physical id: 1.2
+             bus info: pci@0000:00:01.2
+             version: 00
+             width: 32 bits
+             clock: 33MHz
+             capabilities: pci pm pciexpress msi ht normal_decode bus_master cap_list
+             configuration: driver=pcieport
+             resources: irq:28 ioport:d000(size=8192) memory:fc500000-fcafffff
+           *-pci
+                description: PCI bridge
+                product: Matisse Switch Upstream
+                vendor: Advanced Micro Devices, Inc. [AMD]
+                physical id: 0
+                bus info: pci@0000:02:00.0
+                version: 00
+                width: 32 bits
+                clock: 33MHz
+                capabilities: pci pm pciexpress msi normal_decode bus_master cap_list
+                configuration: driver=pcieport
+                resources: irq:24 ioport:d000(size=8192) memory:fc500000-fcafffff
+              *-pci:0
+                   description: PCI bridge
+                   product: Matisse PCIe GPP Bridge
+                   vendor: Advanced Micro Devices, Inc. [AMD]
+                   physical id: 3
+                   bus info: pci@0000:03:03.0
+                   version: 00
+                   width: 32 bits
+                   clock: 33MHz
+                   capabilities: pci pm pciexpress msi ht normal_decode bus_master cap_list
+                   configuration: driver=pcieport
+                   resources: irq:33 ioport:e000(size=4096) memory:fca00000-fcafffff
+                 *-network
+                      description: Ethernet interface
+                      product: RTL8125 2.5GbE Controller
+                      vendor: Realtek Semiconductor Co., Ltd.
+                      physical id: 0
+                      bus info: pci@0000:04:00.0
+                      logical name: enp4s0
+                      version: 00
+                      serial: 24:4b:fe:52:cb:06
+                      capacity: 1Gbit/s
+                      width: 64 bits
+                      clock: 33MHz
+                      capabilities: pm msi pciexpress msix vpd bus_master cap_list rom ethernet physical tp mii 10bt 10bt-fd 100bt 100bt-fd 1000bt-fd autonegotiation
+                      configuration: autonegotiation=on broadcast=yes driver=r8169 driverversion=5.10.27-gentoo-FrostEyes firmware=rtl8125a-3_0.0.1 08/24/19 latency=0 link=no multicast=yes port=twisted pair
+                      resources: irq:59 ioport:e000(size=256) memory:fca10000-fca1ffff memory:fca20000-fca23fff memory:fca00000-fca0ffff memory:fca30000-fca9ffff memory:fcaa0000-fcabbfff
+              *-pci:1
+                   description: PCI bridge
+                   product: Matisse PCIe GPP Bridge
+                   vendor: Advanced Micro Devices, Inc. [AMD]
+                   physical id: 5
+                   bus info: pci@0000:03:05.0
+                   version: 00
+                   width: 32 bits
+                   clock: 33MHz
+                   capabilities: pci pm pciexpress msi ht normal_decode bus_master cap_list
+                   configuration: driver=pcieport
+                   resources: irq:34 ioport:d000(size=4096) memory:fc900000-fc9fffff
+                 *-network
+                      description: Ethernet interface
+                      product: I211 Gigabit Network Connection
+                      vendor: Intel Corporation
+                      physical id: 0
+                      bus info: pci@0000:05:00.0
+                      logical name: enp5s0
+                      version: 03
+                      serial: 24:4b:fe:52:cb:05
+                      size: 1Gbit/s
+                      capacity: 1Gbit/s
+                      width: 32 bits
+                      clock: 33MHz
+                      capabilities: pm msi msix pciexpress bus_master cap_list ethernet physical tp 10bt 10bt-fd 100bt 100bt-fd 1000bt-fd autonegotiation
+                      configuration: autonegotiation=on broadcast=yes driver=igb driverversion=5.10.27-gentoo-FrostEyes duplex=full firmware=0. 6-1 ip=192.168.1.70 latency=0 link=yes multicast=yes port=twisted pair speed=1Gbit/s
+                      resources: irq:36 memory:fc900000-fc91ffff ioport:d000(size=32) memory:fc920000-fc923fff
+              *-pci:2
+                   description: PCI bridge
+                   product: Matisse PCIe GPP Bridge
+                   vendor: Advanced Micro Devices, Inc. [AMD]
+                   physical id: 8
+                   bus info: pci@0000:03:08.0
+                   version: 00
+                   width: 32 bits
+                   clock: 33MHz
+                   capabilities: pci pm pciexpress msi ht normal_decode bus_master cap_list
+                   configuration: driver=pcieport
+                   resources: irq:35 memory:fc500000-fc6fffff
+                 *-generic UNCLAIMED
+                      description: Non-Essential Instrumentation
+                      product: Starship/Matisse Reserved SPP
+                      vendor: Advanced Micro Devices, Inc. [AMD]
+                      physical id: 0
+                      bus info: pci@0000:06:00.0
+                      version: 00
+                      width: 32 bits
+                      clock: 33MHz
+                      capabilities: pm pciexpress cap_list
+                      configuration: latency=0
+                 *-usb:0
+                      description: USB controller
+                      product: Matisse USB 3.0 Host Controller
+                      vendor: Advanced Micro Devices, Inc. [AMD]
+                      physical id: 0.1
+                      bus info: pci@0000:06:00.1
+                      version: 00
+                      width: 64 bits
+                      clock: 33MHz
+                      capabilities: pm pciexpress msi xhci bus_master cap_list
+                      configuration: driver=xhci_hcd latency=0
+                      resources: irq:61 memory:fc600000-fc6fffff
+                    *-usbhost:0
+                         product: xHCI Host Controller
+                         vendor: Linux 5.10.27-gentoo-FrostEyes xhci-hcd
+                         physical id: 0
+                         bus info: usb@1
+                         logical name: usb1
+                         version: 5.10
+                         capabilities: usb-2.00
+                         configuration: driver=hub slots=6 speed=480Mbit/s
+                       *-usb
+                            description: USB hub
+                            product: USB2.0 Hub
+                            vendor: Genesys Logic, Inc.
+                            physical id: 5
+                            bus info: usb@1:5
+                            version: 32.98
+                            capabilities: usb-2.00
+                            configuration: driver=hub maxpower=100mA slots=4 speed=480Mbit/s
+                          *-usb
+                               description: Human interface device
+                               product: AURA LED Controller
+                               vendor: AsusTek Computer Inc.
+                               physical id: 3
+                               bus info: usb@1:5.3
+                               version: 1.00
+                               serial: 9876543210
+                               capabilities: usb-2.00
+                               configuration: driver=usbhid maxpower=16mA speed=12Mbit/s
+                    *-usbhost:1
+                         product: xHCI Host Controller
+                         vendor: Linux 5.10.27-gentoo-FrostEyes xhci-hcd
+                         physical id: 1
+                         bus info: usb@2
+                         logical name: usb2
+                         version: 5.10
+                         capabilities: usb-3.10
+                         configuration: driver=hub slots=4 speed=10000Mbit/s
+                 *-usb:1
+                      description: USB controller
+                      product: Matisse USB 3.0 Host Controller
+                      vendor: Advanced Micro Devices, Inc. [AMD]
+                      physical id: 0.3
+                      bus info: pci@0000:06:00.3
+                      version: 00
+                      width: 64 bits
+                      clock: 33MHz
+                      capabilities: pm pciexpress msi msix xhci bus_master cap_list
+                      configuration: driver=xhci_hcd latency=0
+                      resources: irq:38 memory:fc500000-fc5fffff
+                    *-usbhost:0
+                         product: xHCI Host Controller
+                         vendor: Linux 5.10.27-gentoo-FrostEyes xhci-hcd
+                         physical id: 0
+                         bus info: usb@3
+                         logical name: usb3
+                         version: 5.10
+                         capabilities: usb-2.00
+                         configuration: driver=hub slots=6 speed=480Mbit/s
+                       *-usb
+                            description: USB hub
+                            product: ASM107x
+                            vendor: ASUS TEK.
+                            physical id: 2
+                            bus info: usb@3:2
+                            version: 0.01
+                            capabilities: usb-2.10
+                            configuration: driver=hub maxpower=100mA slots=4 speed=480Mbit/s
+                          *-usb:0
+                               description: USB hub
+                               product: TUSB8041 4-Port Hub
+                               vendor: Texas Instruments, Inc.
+                               physical id: 1
+                               bus info: usb@3:2.1
+                               version: 1.00
+                               serial: 2901006924FF
+                               capabilities: usb-2.10
+                               configuration: driver=hub slots=4 speed=480Mbit/s
+                             *-usb:0
+                                  description: Mouse
+                                  product: USB-PS/2 Optical Mouse
+                                  vendor: Logitech
+                                  physical id: 1
+                                  bus info: usb@3:2.1.1
+                                  version: 27.20
+                                  capabilities: usb-2.00
+                                  configuration: driver=usbhid maxpower=98mA speed=1Mbit/s
+                             *-usb:1
+                                  description: Keyboard
+                                  product: USB Keyboard
+                                  vendor: Logitech
+                                  physical id: 2
+                                  bus info: usb@3:2.1.2
+                                  version: 86.00
+                                  capabilities: usb-1.10
+                                  configuration: driver=usbhid maxpower=98mA speed=1Mbit/s
+                             *-usb:2
+                                  description: USB hub
+                                  product: TUSB8041 4-Port Hub
+                                  vendor: Texas Instruments, Inc.
+                                  physical id: 3
+                                  bus info: usb@3:2.1.3
+                                  version: 1.00
+                                  serial: 3901006924FF
+                                  capabilities: usb-2.10
+                                  configuration: driver=hub slots=4 speed=480Mbit/s
+                                *-usb
+                                     description: USB hub
+                                     product: USB2.1 Hub
+                                     vendor: GenesysLogic
+                                     physical id: 1
+                                     bus info: usb@3:2.1.3.1
+                                     version: 93.07
+                                     capabilities: usb-2.10
+                                     configuration: driver=hub maxpower=100mA slots=4 speed=480Mbit/s
+                                   *-usb
+                                        description: USB hub
+                                        product: USB2.1 Hub
+                                        vendor: GenesysLogic
+                                        physical id: 4
+                                        bus info: usb@3:2.1.3.1.4
+                                        version: 93.07
+                                        capabilities: usb-2.10
+                                        configuration: driver=hub maxpower=100mA slots=4 speed=480Mbit/s
+                                      *-usb
+                                           description: Generic USB device
+                                           product: TTL232R-3V3
+                                           vendor: FTDI
+                                           physical id: 1
+                                           bus info: usb@3:2.1.3.1.4.1
+                                           version: 6.00
+                                           serial: FT9PNO6D
+                                           capabilities: usb-2.00
+                                           configuration: driver=ftdi_sio maxpower=90mA speed=12Mbit/s
+                             *-usb:3
+                                  description: Human interface device
+                                  product: Texas Instruments USBtoI2C Solution
+                                  vendor: Texas Instruments
+                                  physical id: 4
+                                  bus info: usb@3:2.1.4
+                                  version: 1.00
+                                  capabilities: usb-1.10
+                                  configuration: driver=usbhid maxpower=100mA speed=12Mbit/s
+                          *-usb:1
+                               description: USB hub
+                               product: TUSB8041 4-Port Hub
+                               vendor: Texas Instruments, Inc.
+                               physical id: 2
+                               bus info: usb@3:2.2
+                               version: 1.00
+                               serial: 630A08615820
+                               capabilities: usb-2.10
+                               configuration: driver=hub slots=4 speed=480Mbit/s
+                             *-usb:0
+                                  description: USB hub
+                                  product: TUSB8041 4-Port Hub
+                                  vendor: Texas Instruments, Inc.
+                                  physical id: 3
+                                  bus info: usb@3:2.2.3
+                                  version: 1.00
+                                  serial: 930A00715820
+                                  capabilities: usb-2.10
+                                  configuration: driver=hub slots=4 speed=480Mbit/s
+                             *-usb:1
+                                  description: Human interface device
+                                  product: Texas Instruments USBtoI2C Solution
+                                  vendor: Texas Instruments
+                                  physical id: 4
+                                  bus info: usb@3:2.2.4
+                                  version: 1.00
+                                  capabilities: usb-1.10
+                                  configuration: driver=usbhid maxpower=100mA speed=12Mbit/s
+                    *-usbhost:1
+                         product: xHCI Host Controller
+                         vendor: Linux 5.10.27-gentoo-FrostEyes xhci-hcd
+                         physical id: 1
+                         bus info: usb@4
+                         logical name: usb4
+                         version: 5.10
+                         capabilities: usb-3.10
+                         configuration: driver=hub slots=4 speed=10000Mbit/s
+                       *-usb
+                            description: USB hub
+                            product: ASM107x
+                            vendor: ASUS TEK.
+                            physical id: 2
+                            bus info: usb@4:2
+                            version: 0.01
+                            capabilities: usb-3.00
+                            configuration: driver=hub maxpower=8mA slots=4 speed=5000Mbit/s
+                          *-usb
+                               description: USB hub
+                               product: TUSB8041 4-Port Hub
+                               vendor: Texas Instruments, Inc.
+                               physical id: 1
+                               bus info: usb@4:2.1
+                               version: 1.00
+                               capabilities: usb-3.00
+                               configuration: driver=hub slots=4 speed=5000Mbit/s
+                             *-usb
+                                  description: USB hub
+                                  product: TUSB8041 4-Port Hub
+                                  vendor: Texas Instruments, Inc.
+                                  physical id: 3
+                                  bus info: usb@4:2.1.3
+                                  version: 1.00
+                                  capabilities: usb-3.00
+                                  configuration: driver=hub slots=4 speed=5000Mbit/s
+                                *-usb
+                                     description: USB hub
+                                     product: USB3.2 Hub
+                                     vendor: GenesysLogic
+                                     physical id: 1
+                                     bus info: usb@4:2.1.3.1
+                                     version: 93.07
+                                     capabilities: usb-3.20
+                                     configuration: driver=hub slots=4 speed=5000Mbit/s
+                                   *-usb
+                                        description: USB hub
+                                        product: USB3.2 Hub
+                                        vendor: GenesysLogic
+                                        physical id: 4
+                                        bus info: usb@4:2.1.3.1.4
+                                        version: 93.07
+                                        capabilities: usb-3.20
+                                        configuration: driver=hub slots=4 speed=5000Mbit/s
+              *-pci:3
+                   description: PCI bridge
+                   product: Matisse PCIe GPP Bridge
+                   vendor: Advanced Micro Devices, Inc. [AMD]
+                   physical id: 9
+                   bus info: pci@0000:03:09.0
+                   version: 00
+                   width: 32 bits
+                   clock: 33MHz
+                   capabilities: pci pm pciexpress msi ht normal_decode bus_master cap_list
+                   configuration: driver=pcieport
+                   resources: irq:37 memory:fc800000-fc8fffff
+                 *-storage
+                      description: SATA controller
+                      product: FCH SATA Controller [AHCI mode]
+                      vendor: Advanced Micro Devices, Inc. [AMD]
+                      physical id: 0
+                      bus info: pci@0000:07:00.0
+                      version: 51
+                      width: 32 bits
+                      clock: 33MHz
+                      capabilities: storage pm pciexpress msi ahci_1.0 bus_master cap_list
+                      configuration: driver=ahci latency=0
+                      resources: irq:44 memory:fc800000-fc8007ff
+              *-pci:4
+                   description: PCI bridge
+                   product: Matisse PCIe GPP Bridge
+                   vendor: Advanced Micro Devices, Inc. [AMD]
+                   physical id: a
+                   bus info: pci@0000:03:0a.0
+                   version: 00
+                   width: 32 bits
+                   clock: 33MHz
+                   capabilities: pci pm pciexpress msi ht normal_decode bus_master cap_list
+                   configuration: driver=pcieport
+                   resources: irq:39 memory:fc700000-fc7fffff
+                 *-storage
+                      description: SATA controller
+                      product: FCH SATA Controller [AHCI mode]
+                      vendor: Advanced Micro Devices, Inc. [AMD]
+                      physical id: 0
+                      bus info: pci@0000:08:00.0
+                      version: 51
+                      width: 32 bits
+                      clock: 33MHz
+                      capabilities: storage pm pciexpress msi ahci_1.0 bus_master cap_list
+                      configuration: driver=ahci latency=0
+                      resources: irq:45 memory:fc700000-fc7007ff
+        *-pci:2
+             description: PCI bridge
+             product: Starship/Matisse GPP Bridge
+             vendor: Advanced Micro Devices, Inc. [AMD]
+             physical id: 3.1
+             bus info: pci@0000:00:03.1
+             version: 00
+             width: 32 bits
+             clock: 33MHz
+             capabilities: pci pm pciexpress msi ht normal_decode bus_master cap_list
+             configuration: driver=pcieport
+             resources: irq:29 ioport:f000(size=4096) memory:fce00000-fcefffff ioport:d0000000(size=270532608)
+           *-display
+                description: VGA compatible controller
+                product: Ellesmere [Radeon RX 470/480/570/570X/580/580X/590]
+                vendor: Advanced Micro Devices, Inc. [AMD/ATI]
+                physical id: 0
+                bus info: pci@0000:09:00.0
+                version: ef
+                width: 64 bits
+                clock: 33MHz
+                capabilities: pm pciexpress msi vga_controller bus_master cap_list rom
+                configuration: driver=amdgpu latency=0
+                resources: irq:41 memory:d0000000-dfffffff memory:e0000000-e01fffff ioport:f000(size=256) memory:fce00000-fce3ffff memory:fce40000-fce5ffff
+           *-multimedia
+                description: Audio device
+                product: Ellesmere HDMI Audio [Radeon RX 470/480 / 570/580/590]
+                vendor: Advanced Micro Devices, Inc. [AMD/ATI]
+                physical id: 0.1
+                bus info: pci@0000:09:00.1
+                version: 00
+                width: 64 bits
+                clock: 33MHz
+                capabilities: pm pciexpress msi bus_master cap_list
+                configuration: driver=snd_hda_intel latency=0
+                resources: irq:80 memory:fce60000-fce63fff
+        *-pci:3
+             description: PCI bridge
+             product: Starship/Matisse Internal PCIe GPP Bridge 0 to bus[E:B]
+             vendor: Advanced Micro Devices, Inc. [AMD]
+             physical id: 7.1
+             bus info: pci@0000:00:07.1
+             version: 00
+             width: 32 bits
+             clock: 33MHz
+             capabilities: pci pm pciexpress msi ht normal_decode bus_master cap_list
+             configuration: driver=pcieport
+             resources: irq:31
+           *-generic UNCLAIMED
+                description: Non-Essential Instrumentation
+                product: Starship/Matisse PCIe Dummy Function
+                vendor: Advanced Micro Devices, Inc. [AMD]
+                physical id: 0
+                bus info: pci@0000:0a:00.0
+                version: 00
+                width: 32 bits
+                clock: 33MHz
+                capabilities: pm pciexpress cap_list
+                configuration: latency=0
+        *-pci:4
+             description: PCI bridge
+             product: Starship/Matisse Internal PCIe GPP Bridge 0 to bus[E:B]
+             vendor: Advanced Micro Devices, Inc. [AMD]
+             physical id: 8.1
+             bus info: pci@0000:00:08.1
+             version: 00
+             width: 32 bits
+             clock: 33MHz
+             capabilities: pci pm pciexpress msi ht normal_decode bus_master cap_list
+             configuration: driver=pcieport
+             resources: irq:32 memory:fcb00000-fcdfffff
+           *-generic:0 UNCLAIMED
+                description: Non-Essential Instrumentation
+                product: Starship/Matisse Reserved SPP
+                vendor: Advanced Micro Devices, Inc. [AMD]
+                physical id: 0
+                bus info: pci@0000:0b:00.0
+                version: 00
+                width: 32 bits
+                clock: 33MHz
+                capabilities: pm pciexpress cap_list
+                configuration: latency=0
+           *-generic:1 UNCLAIMED
+                description: Encryption controller
+                product: Starship/Matisse Cryptographic Coprocessor PSPCPP
+                vendor: Advanced Micro Devices, Inc. [AMD]
+                physical id: 0.1
+                bus info: pci@0000:0b:00.1
+                version: 00
+                width: 32 bits
+                clock: 33MHz
+                capabilities: pm pciexpress msi msix cap_list
+                configuration: latency=0
+                resources: memory:fcc00000-fccfffff memory:fcd08000-fcd09fff
+           *-usb
+                description: USB controller
+                product: Matisse USB 3.0 Host Controller
+                vendor: Advanced Micro Devices, Inc. [AMD]
+                physical id: 0.3
+                bus info: pci@0000:0b:00.3
+                version: 00
+                width: 64 bits
+                clock: 33MHz
+                capabilities: pm pciexpress msi msix xhci bus_master cap_list
+                configuration: driver=xhci_hcd latency=0
+                resources: irq:70 memory:fcb00000-fcbfffff
+              *-usbhost:0
+                   product: xHCI Host Controller
+                   vendor: Linux 5.10.27-gentoo-FrostEyes xhci-hcd
+                   physical id: 0
+                   bus info: usb@5
+                   logical name: usb5
+                   version: 5.10
+                   capabilities: usb-2.00
+                   configuration: driver=hub slots=4 speed=480Mbit/s
+              *-usbhost:1
+                   product: xHCI Host Controller
+                   vendor: Linux 5.10.27-gentoo-FrostEyes xhci-hcd
+                   physical id: 1
+                   bus info: usb@6
+                   logical name: usb6
+                   version: 5.10
+                   capabilities: usb-3.10
+                   configuration: driver=hub slots=4 speed=10000Mbit/s
+           *-multimedia
+                description: Audio device
+                product: Starship/Matisse HD Audio Controller
+                vendor: Advanced Micro Devices, Inc. [AMD]
+                physical id: 0.4
+                bus info: pci@0000:0b:00.4
+                version: 00
+                width: 32 bits
+                clock: 33MHz
+                capabilities: pm pciexpress msi bus_master cap_list
+                configuration: driver=snd_hda_intel latency=0
+                resources: irq:82 memory:fcd00000-fcd07fff
+        *-serial UNCLAIMED
+             description: SMBus
+             product: FCH SMBus Controller
+             vendor: Advanced Micro Devices, Inc. [AMD]
+             physical id: 14
+             bus info: pci@0000:00:14.0
+             version: 61
+             width: 32 bits
+             clock: 66MHz
+             configuration: latency=0
+        *-isa
+             description: ISA bridge
+             product: FCH LPC Bridge
+             vendor: Advanced Micro Devices, Inc. [AMD]
+             physical id: 14.3
+             bus info: pci@0000:00:14.3
+             version: 51
+             width: 32 bits
+             clock: 66MHz
+             capabilities: isa bus_master
+             configuration: latency=0
+     *-pci:1
+          description: Host bridge
+          product: Starship/Matisse PCIe Dummy Host Bridge
+          vendor: Advanced Micro Devices, Inc. [AMD]
+          physical id: 101
+          bus info: pci@0000:00:01.0
+          version: 00
+          width: 32 bits
+          clock: 33MHz
+     *-pci:2
+          description: Host bridge
+          product: Starship/Matisse PCIe Dummy Host Bridge
+          vendor: Advanced Micro Devices, Inc. [AMD]
+          physical id: 102
+          bus info: pci@0000:00:02.0
+          version: 00
+          width: 32 bits
+          clock: 33MHz
+     *-pci:3
+          description: Host bridge
+          product: Starship/Matisse PCIe Dummy Host Bridge
+          vendor: Advanced Micro Devices, Inc. [AMD]
+          physical id: 103
+          bus info: pci@0000:00:03.0
+          version: 00
+          width: 32 bits
+          clock: 33MHz
+     *-pci:4
+          description: Host bridge
+          product: Starship/Matisse PCIe Dummy Host Bridge
+          vendor: Advanced Micro Devices, Inc. [AMD]
+          physical id: 104
+          bus info: pci@0000:00:04.0
+          version: 00
+          width: 32 bits
+          clock: 33MHz
+     *-pci:5
+          description: Host bridge
+          product: Starship/Matisse PCIe Dummy Host Bridge
+          vendor: Advanced Micro Devices, Inc. [AMD]
+          physical id: 105
+          bus info: pci@0000:00:05.0
+          version: 00
+          width: 32 bits
+          clock: 33MHz
+     *-pci:6
+          description: Host bridge
+          product: Starship/Matisse PCIe Dummy Host Bridge
+          vendor: Advanced Micro Devices, Inc. [AMD]
+          physical id: 106
+          bus info: pci@0000:00:07.0
+          version: 00
+          width: 32 bits
+          clock: 33MHz
+     *-pci:7
+          description: Host bridge
+          product: Starship/Matisse PCIe Dummy Host Bridge
+          vendor: Advanced Micro Devices, Inc. [AMD]
+          physical id: 107
+          bus info: pci@0000:00:08.0
+          version: 00
+          width: 32 bits
+          clock: 33MHz
+     *-pci:8
+          description: Host bridge
+          product: Matisse Device 24: Function 0
+          vendor: Advanced Micro Devices, Inc. [AMD]
+          physical id: 108
+          bus info: pci@0000:00:18.0
+          version: 00
+          width: 32 bits
+          clock: 33MHz
+     *-pci:9
+          description: Host bridge
+          product: Matisse Device 24: Function 1
+          vendor: Advanced Micro Devices, Inc. [AMD]
+          physical id: 109
+          bus info: pci@0000:00:18.1
+          version: 00
+          width: 32 bits
+          clock: 33MHz
+     *-pci:10
+          description: Host bridge
+          product: Matisse Device 24: Function 2
+          vendor: Advanced Micro Devices, Inc. [AMD]
+          physical id: 10a
+          bus info: pci@0000:00:18.2
+          version: 00
+          width: 32 bits
+          clock: 33MHz
+     *-pci:11
+          description: Host bridge
+          product: Matisse Device 24: Function 3
+          vendor: Advanced Micro Devices, Inc. [AMD]
+          physical id: 10b
+          bus info: pci@0000:00:18.3
+          version: 00
+          width: 32 bits
+          clock: 33MHz
+          configuration: driver=k10temp
+          resources: irq:0
+     *-pci:12
+          description: Host bridge
+          product: Matisse Device 24: Function 4
+          vendor: Advanced Micro Devices, Inc. [AMD]
+          physical id: 10c
+          bus info: pci@0000:00:18.4
+          version: 00
+          width: 32 bits
+          clock: 33MHz
+     *-pci:13
+          description: Host bridge
+          product: Matisse Device 24: Function 5
+          vendor: Advanced Micro Devices, Inc. [AMD]
+          physical id: 10d
+          bus info: pci@0000:00:18.5
+          version: 00
+          width: 32 bits
+          clock: 33MHz
+     *-pci:14
+          description: Host bridge
+          product: Matisse Device 24: Function 6
+          vendor: Advanced Micro Devices, Inc. [AMD]
+          physical id: 10e
+          bus info: pci@0000:00:18.6
+          version: 00
+          width: 32 bits
+          clock: 33MHz
+     *-pci:15
+          description: Host bridge
+          product: Matisse Device 24: Function 7
+          vendor: Advanced Micro Devices, Inc. [AMD]
+          physical id: 10f
+          bus info: pci@0000:00:18.7
+          version: 00
+          width: 32 bits
+          clock: 33MHz
+     *-scsi:0
+          physical id: 1
+          logical name: scsi2
+          capabilities: emulated
+        *-disk
+             description: ATA Disk
+             product: KINGSTON SA400S3
+             physical id: 0.0.0
+             bus info: scsi@2:0.0.0
+             logical name: /dev/sda
+             version: B1D1
+             serial: 50026B7782A80FC5
+             size: 447GiB (480GB)
+             capabilities: gpt-1.00 partitioned partitioned:gpt
+             configuration: ansiversion=5 guid=934e5e2b-2fac-4e40-afdb-7ffe29d50d95 logicalsectorsize=512 sectorsize=512
+           *-volume
+                description: EXT4 volume
+                vendor: Linux
+                physical id: 1
+                bus info: scsi@2:0.0.0,1
+                logical name: /dev/sda1
+                logical name: /home/frosteyes/Echo
+                version: 1.0
+                serial: b0aecac2-9652-4d5f-b3c2-54f7814cef2c
+                size: 447GiB
+                capacity: 447GiB
+                capabilities: journaled extended_attributes large_files huge_files dir_nlink recover 64bit extents ext4 ext2 initialized
+                configuration: created=2019-11-27 22:08:55 filesystem=ext4 lastmountpoint=/home/frosteyes/Echo modified=2021-05-03 12:42:19 mount.fstype=ext4 mount.options=rw,noatime mounted=2021-05-03 12:42:19 name=Linux filesystem state=mounted
+     *-scsi:1
+          physical id: 2
+          logical name: scsi3
+          capabilities: emulated
+        *-disk
+             description: ATA Disk
+             product: Samsung SSD 840
+             physical id: 0.0.0
+             bus info: scsi@3:0.0.0
+             logical name: /dev/sdb
+             version: BB6Q
+             serial: S1DHNSAF404404F
+             size: 465GiB (500GB)
+             capabilities: gpt-1.00 partitioned partitioned:gpt
+             configuration: ansiversion=5 guid=7e858452-3dc7-46ad-84c2-b97ddcc2a19b logicalsectorsize=512 sectorsize=512
+           *-volume
+                description: Windows NTFS volume
+                vendor: Windows
+                physical id: 1
+                bus info: scsi@3:0.0.0,1
+                logical name: /dev/sdb1
+                version: 3.1
+                serial: d0855811-8e12-d54f-989d-69219db61874
+                size: 465GiB
+                capacity: 465GiB
+                capabilities: ntfs initialized
+                configuration: clustersize=4096 created=2020-12-29 18:31:03 filesystem=ntfs name=Basic data partition state=clean
+     *-scsi:2
+          physical id: 3
+          logical name: scsi8
+          capabilities: emulated
+        *-disk
+             description: ATA Disk
+             product: CT2000MX500SSD1
+             physical id: 0.0.0
+             bus info: scsi@8:0.0.0
+             logical name: /dev/sdc
+             version: 033
+             serial: mebdD6-Grhs-FXhO-Xmyo-jcJP-x3pb-ZI1TMF
+             size: 1863GiB
+             capacity: 1863GiB
+             capabilities: lvm2
+             configuration: ansiversion=5 logicalsectorsize=512 sectorsize=4096
+     *-scsi:3
+          physical id: 4
+          logical name: scsi9
+          capabilities: emulated
+        *-disk
+             description: ATA Disk
+             product: CT2000MX500SSD1
+             physical id: 0.0.0
+             bus info: scsi@9:0.0.0
+             logical name: /dev/sdd
+             version: 033
+             serial: TOHCzZ-2lh3-6rtf-nPgz-9fOy-mlI5-XqMeiB
+             size: 1863GiB
+             capacity: 1863GiB
+             capabilities: lvm2
+             configuration: ansiversion=5 logicalsectorsize=512 sectorsize=4096
+  *-network:0 DISABLED
+       description: Ethernet interface
+       physical id: 1
+       logical name: dummy0
+       serial: 6a:30:45:6a:c6:9e
+       capabilities: ethernet physical
+       configuration: broadcast=yes driver=dummy driverversion=5.10.27-gentoo-FrostEyes
+  *-network:1
+       description: Ethernet interface
+       physical id: 2
+       logical name: br-dbf5911d131d
+       serial: 02:42:9b:b6:9b:ed
+       capabilities: ethernet physical
+       configuration: autonegotiation=off broadcast=yes driver=bridge driverversion=2.3 firmware=N/A ip=172.18.0.1 link=no multicast=yes
+  *-network:2
+       description: Ethernet interface
+       physical id: 3
+       logical name: docker0
+       serial: 02:42:4c:51:04:13
+       capabilities: ethernet physical
+       configuration: autonegotiation=off broadcast=yes driver=bridge driverversion=2.3 firmware=N/A ip=172.17.0.1 link=no multicast=yes

--- a/ryzen-9-5950x-128gb-docker-zeus-individual-components-tmpfs/8-build-individual-components.16.chromium-x11.log
+++ b/ryzen-9-5950x-128gb-docker-zeus-individual-components-tmpfs/8-build-individual-components.16.chromium-x11.log
@@ -1,0 +1,35 @@
+Loading cache...done.
+Loaded 2448 entries from dependency cache.
+NOTE: Resolving any missing task queue dependencies
+
+Build Configuration:
+BB_VERSION           = "1.44.0"
+BUILD_SYS            = "x86_64-linux"
+NATIVELSBSTRING      = "universal"
+TARGET_SYS           = "x86_64-poky-linux"
+MACHINE              = "qemux86-64"
+DISTRO               = "poky"
+DISTRO_VERSION       = "3.0.2"
+TUNE_FEATURES        = "m64 core2"
+TARGET_FPU           = ""
+meta                 
+meta-poky            
+meta-yocto-bsp       = "zeus:341f87a6ba32f900c744c26d026c5aad6e19c09d"
+meta-browser         = "zeus:1697014a05967ed54b294f3c4b5621df494d6551"
+meta-rust            = "zeus:5d1ada0c97723e1526bf5599b2fa2cbb56c2c0dc"
+meta-oe              = "zeus:e855ecc6d35677e79780adc57b2552213c995731"
+meta-clang           = "zeus:0c393398a91713a108f319ac75337c02b7ebeaa7"
+meta-qt5             = "zeus:a582fd4c810529e9af0c81700407b1955d1391d2"
+
+Initialising tasks...done.
+Sstate summary: Wanted 0 Found 0 Missed 0 Current 232 (0% match, 100% complete)
+NOTE: Executing Tasks
+NOTE: Setscene tasks completed
+NOTE: Running task 1912 of 1913 (/home/yocto/oe-test/test-oe-build-time/poky/meta-browser/recipes-browser/chromium/chromium-x11_79.0.3945.117.bb:do_add_nodejs_symlink)
+NOTE: recipe chromium-x11-79.0.3945.117-r0: task do_add_nodejs_symlink: Started
+NOTE: recipe chromium-x11-79.0.3945.117-r0: task do_add_nodejs_symlink: Succeeded
+NOTE: Running task 1913 of 1913 (/home/yocto/oe-test/test-oe-build-time/poky/meta-browser/recipes-browser/chromium/chromium-x11_79.0.3945.117.bb:do_compile)
+NOTE: recipe chromium-x11-79.0.3945.117-r0: task do_compile: Started
+NOTE: recipe chromium-x11-79.0.3945.117-r0: task do_compile: Succeeded
+NOTE: Tasks Summary: Attempted 1913 tasks of which 1911 didn't need to be rerun and all succeeded.
+TIME: 3547.38 0.78 8.22 0% 647 142400 9360 0 27916 0 bitbake -c compile chromium-x11

--- a/ryzen-9-5950x-128gb-docker-zeus-individual-components-tmpfs/8-build-individual-components.16.qtbase.log
+++ b/ryzen-9-5950x-128gb-docker-zeus-individual-components-tmpfs/8-build-individual-components.16.qtbase.log
@@ -1,0 +1,35 @@
+Loading cache...done.
+Loaded 2448 entries from dependency cache.
+NOTE: Resolving any missing task queue dependencies
+
+Build Configuration:
+BB_VERSION           = "1.44.0"
+BUILD_SYS            = "x86_64-linux"
+NATIVELSBSTRING      = "universal"
+TARGET_SYS           = "x86_64-poky-linux"
+MACHINE              = "qemux86-64"
+DISTRO               = "poky"
+DISTRO_VERSION       = "3.0.2"
+TUNE_FEATURES        = "m64 core2"
+TARGET_FPU           = ""
+meta                 
+meta-poky            
+meta-yocto-bsp       = "zeus:341f87a6ba32f900c744c26d026c5aad6e19c09d"
+meta-browser         = "zeus:1697014a05967ed54b294f3c4b5621df494d6551"
+meta-rust            = "zeus:5d1ada0c97723e1526bf5599b2fa2cbb56c2c0dc"
+meta-oe              = "zeus:e855ecc6d35677e79780adc57b2552213c995731"
+meta-clang           = "zeus:0c393398a91713a108f319ac75337c02b7ebeaa7"
+meta-qt5             = "zeus:a582fd4c810529e9af0c81700407b1955d1391d2"
+
+Initialising tasks...done.
+Sstate summary: Wanted 0 Found 0 Missed 0 Current 138 (0% match, 100% complete)
+NOTE: Executing Tasks
+NOTE: Setscene tasks completed
+NOTE: Running task 1131 of 1132 (/home/yocto/oe-test/test-oe-build-time/poky/meta-qt5/recipes-qt/qt5/qtbase_git.bb:do_configure_ptest_base)
+NOTE: recipe qtbase-5.13.2+gitAUTOINC+a7a24784ee-r0: task do_configure_ptest_base: Started
+NOTE: recipe qtbase-5.13.2+gitAUTOINC+a7a24784ee-r0: task do_configure_ptest_base: Succeeded
+NOTE: Running task 1132 of 1132 (/home/yocto/oe-test/test-oe-build-time/poky/meta-qt5/recipes-qt/qt5/qtbase_git.bb:do_compile)
+NOTE: recipe qtbase-5.13.2+gitAUTOINC+a7a24784ee-r0: task do_compile: Started
+NOTE: recipe qtbase-5.13.2+gitAUTOINC+a7a24784ee-r0: task do_compile: Succeeded
+NOTE: Tasks Summary: Attempted 1132 tasks of which 1130 didn't need to be rerun and all succeeded.
+TIME: 398.66 0.04 0.31 0% 11 13607 9361 0 27928 0 bitbake -c compile qtbase

--- a/ryzen-9-5950x-128gb-docker-zeus-individual-components-tmpfs/8-build-individual-components.16.qtdeclarative.log
+++ b/ryzen-9-5950x-128gb-docker-zeus-individual-components-tmpfs/8-build-individual-components.16.qtdeclarative.log
@@ -1,0 +1,35 @@
+Loading cache...done.
+Loaded 2448 entries from dependency cache.
+NOTE: Resolving any missing task queue dependencies
+
+Build Configuration:
+BB_VERSION           = "1.44.0"
+BUILD_SYS            = "x86_64-linux"
+NATIVELSBSTRING      = "universal"
+TARGET_SYS           = "x86_64-poky-linux"
+MACHINE              = "qemux86-64"
+DISTRO               = "poky"
+DISTRO_VERSION       = "3.0.2"
+TUNE_FEATURES        = "m64 core2"
+TARGET_FPU           = ""
+meta                 
+meta-poky            
+meta-yocto-bsp       = "zeus:341f87a6ba32f900c744c26d026c5aad6e19c09d"
+meta-browser         = "zeus:1697014a05967ed54b294f3c4b5621df494d6551"
+meta-rust            = "zeus:5d1ada0c97723e1526bf5599b2fa2cbb56c2c0dc"
+meta-oe              = "zeus:e855ecc6d35677e79780adc57b2552213c995731"
+meta-clang           = "zeus:0c393398a91713a108f319ac75337c02b7ebeaa7"
+meta-qt5             = "zeus:a582fd4c810529e9af0c81700407b1955d1391d2"
+
+Initialising tasks...done.
+Sstate summary: Wanted 0 Found 0 Missed 0 Current 139 (0% match, 100% complete)
+NOTE: Executing Tasks
+NOTE: Setscene tasks completed
+NOTE: Running task 1143 of 1144 (/home/yocto/oe-test/test-oe-build-time/poky/meta-qt5/recipes-qt/qt5/qtdeclarative_git.bb:do_configure_ptest_base)
+NOTE: recipe qtdeclarative-5.13.2+gitAUTOINC+4080025fed-r0: task do_configure_ptest_base: Started
+NOTE: recipe qtdeclarative-5.13.2+gitAUTOINC+4080025fed-r0: task do_configure_ptest_base: Succeeded
+NOTE: Running task 1144 of 1144 (/home/yocto/oe-test/test-oe-build-time/poky/meta-qt5/recipes-qt/qt5/qtdeclarative_git.bb:do_compile)
+NOTE: recipe qtdeclarative-5.13.2+gitAUTOINC+4080025fed-r0: task do_compile: Started
+NOTE: recipe qtdeclarative-5.13.2+gitAUTOINC+4080025fed-r0: task do_compile: Succeeded
+NOTE: Tasks Summary: Attempted 1144 tasks of which 1142 didn't need to be rerun and all succeeded.
+TIME: 172.34 0.03 0.27 0% 7 11722 9368 0 28012 0 bitbake -c compile qtdeclarative

--- a/ryzen-9-5950x-128gb-docker-zeus-individual-components-tmpfs/8-build-individual-components.16.qtwebengine.log
+++ b/ryzen-9-5950x-128gb-docker-zeus-individual-components-tmpfs/8-build-individual-components.16.qtwebengine.log
@@ -1,0 +1,32 @@
+Loading cache...done.
+Loaded 2448 entries from dependency cache.
+NOTE: Resolving any missing task queue dependencies
+
+Build Configuration:
+BB_VERSION           = "1.44.0"
+BUILD_SYS            = "x86_64-linux"
+NATIVELSBSTRING      = "universal"
+TARGET_SYS           = "x86_64-poky-linux"
+MACHINE              = "qemux86-64"
+DISTRO               = "poky"
+DISTRO_VERSION       = "3.0.2"
+TUNE_FEATURES        = "m64 core2"
+TARGET_FPU           = ""
+meta                 
+meta-poky            
+meta-yocto-bsp       = "zeus:341f87a6ba32f900c744c26d026c5aad6e19c09d"
+meta-browser         = "zeus:1697014a05967ed54b294f3c4b5621df494d6551"
+meta-rust            = "zeus:5d1ada0c97723e1526bf5599b2fa2cbb56c2c0dc"
+meta-oe              = "zeus:e855ecc6d35677e79780adc57b2552213c995731"
+meta-clang           = "zeus:0c393398a91713a108f319ac75337c02b7ebeaa7"
+meta-qt5             = "zeus:a582fd4c810529e9af0c81700407b1955d1391d2"
+
+Initialising tasks...done.
+Sstate summary: Wanted 0 Found 0 Missed 0 Current 195 (0% match, 100% complete)
+NOTE: Executing Tasks
+NOTE: Setscene tasks completed
+NOTE: Running task 1619 of 1619 (/home/yocto/oe-test/test-oe-build-time/poky/meta-qt5/recipes-qt/qt5/qtwebengine_git.bb:do_compile)
+NOTE: recipe qtwebengine-5.13.2+gitAUTOINC+556576b55f_843d70ac87-r0: task do_compile: Started
+NOTE: recipe qtwebengine-5.13.2+gitAUTOINC+556576b55f_843d70ac87-r0: task do_compile: Succeeded
+NOTE: Tasks Summary: Attempted 1619 tasks of which 1618 didn't need to be rerun and all succeeded.
+TIME: 1147.18 0.28 2.89 0% 129 63792 9367 0 27900 0 bitbake -c compile qtwebengine

--- a/ryzen-9-5950x-128gb-docker-zeus-individual-components-tmpfs/8-build-individual-components.16.rust-native.log
+++ b/ryzen-9-5950x-128gb-docker-zeus-individual-components-tmpfs/8-build-individual-components.16.rust-native.log
@@ -1,0 +1,35 @@
+Loading cache...done.
+Loaded 2448 entries from dependency cache.
+NOTE: Resolving any missing task queue dependencies
+
+Build Configuration:
+BB_VERSION           = "1.44.0"
+BUILD_SYS            = "x86_64-linux"
+NATIVELSBSTRING      = "universal"
+TARGET_SYS           = "x86_64-poky-linux"
+MACHINE              = "qemux86-64"
+DISTRO               = "poky"
+DISTRO_VERSION       = "3.0.2"
+TUNE_FEATURES        = "m64 core2"
+TARGET_FPU           = ""
+meta                 
+meta-poky            
+meta-yocto-bsp       = "zeus:341f87a6ba32f900c744c26d026c5aad6e19c09d"
+meta-browser         = "zeus:1697014a05967ed54b294f3c4b5621df494d6551"
+meta-rust            = "zeus:5d1ada0c97723e1526bf5599b2fa2cbb56c2c0dc"
+meta-oe              = "zeus:e855ecc6d35677e79780adc57b2552213c995731"
+meta-clang           = "zeus:0c393398a91713a108f319ac75337c02b7ebeaa7"
+meta-qt5             = "zeus:a582fd4c810529e9af0c81700407b1955d1391d2"
+
+Initialising tasks...done.
+Sstate summary: Wanted 0 Found 0 Missed 0 Current 25 (0% match, 100% complete)
+NOTE: Executing Tasks
+NOTE: Setscene tasks completed
+NOTE: Running task 166 of 210 (virtual:native:/home/yocto/oe-test/test-oe-build-time/poky/meta-rust/recipes-devtools/rust/rust_1.37.0.bb:do_rust_gen_targets)
+NOTE: recipe rust-native-1.37.0-r0: task do_rust_gen_targets: Started
+NOTE: recipe rust-native-1.37.0-r0: task do_rust_gen_targets: Succeeded
+NOTE: Running task 210 of 210 (virtual:native:/home/yocto/oe-test/test-oe-build-time/poky/meta-rust/recipes-devtools/rust/rust_1.37.0.bb:do_compile)
+NOTE: recipe rust-native-1.37.0-r0: task do_compile: Started
+NOTE: recipe rust-native-1.37.0-r0: task do_compile: Succeeded
+NOTE: Tasks Summary: Attempted 210 tasks of which 208 didn't need to be rerun and all succeeded.
+TIME: 1030.84 0.02 0.35 0% 26 12240 9357 0 27924 0 bitbake -c compile rust-native

--- a/ryzen-9-5950x-128gb-docker-zeus-individual-components-tmpfs/8-build-individual-components.24.chromium-x11.log
+++ b/ryzen-9-5950x-128gb-docker-zeus-individual-components-tmpfs/8-build-individual-components.24.chromium-x11.log
@@ -1,0 +1,35 @@
+Loading cache...done.
+Loaded 2448 entries from dependency cache.
+NOTE: Resolving any missing task queue dependencies
+
+Build Configuration:
+BB_VERSION           = "1.44.0"
+BUILD_SYS            = "x86_64-linux"
+NATIVELSBSTRING      = "universal"
+TARGET_SYS           = "x86_64-poky-linux"
+MACHINE              = "qemux86-64"
+DISTRO               = "poky"
+DISTRO_VERSION       = "3.0.2"
+TUNE_FEATURES        = "m64 core2"
+TARGET_FPU           = ""
+meta                 
+meta-poky            
+meta-yocto-bsp       = "zeus:341f87a6ba32f900c744c26d026c5aad6e19c09d"
+meta-browser         = "zeus:1697014a05967ed54b294f3c4b5621df494d6551"
+meta-rust            = "zeus:5d1ada0c97723e1526bf5599b2fa2cbb56c2c0dc"
+meta-oe              = "zeus:e855ecc6d35677e79780adc57b2552213c995731"
+meta-clang           = "zeus:0c393398a91713a108f319ac75337c02b7ebeaa7"
+meta-qt5             = "zeus:a582fd4c810529e9af0c81700407b1955d1391d2"
+
+Initialising tasks...done.
+Sstate summary: Wanted 0 Found 0 Missed 0 Current 232 (0% match, 100% complete)
+NOTE: Executing Tasks
+NOTE: Setscene tasks completed
+NOTE: Running task 1912 of 1913 (/home/yocto/oe-test/test-oe-build-time/poky/meta-browser/recipes-browser/chromium/chromium-x11_79.0.3945.117.bb:do_add_nodejs_symlink)
+NOTE: recipe chromium-x11-79.0.3945.117-r0: task do_add_nodejs_symlink: Started
+NOTE: recipe chromium-x11-79.0.3945.117-r0: task do_add_nodejs_symlink: Succeeded
+NOTE: Running task 1913 of 1913 (/home/yocto/oe-test/test-oe-build-time/poky/meta-browser/recipes-browser/chromium/chromium-x11_79.0.3945.117.bb:do_compile)
+NOTE: recipe chromium-x11-79.0.3945.117-r0: task do_compile: Started
+NOTE: recipe chromium-x11-79.0.3945.117-r0: task do_compile: Succeeded
+NOTE: Tasks Summary: Attempted 1913 tasks of which 1911 didn't need to be rerun and all succeeded.
+TIME: 3310.44 0.76 8.89 0% 287 141542 9356 0 27896 0 bitbake -c compile chromium-x11

--- a/ryzen-9-5950x-128gb-docker-zeus-individual-components-tmpfs/8-build-individual-components.24.qtbase.log
+++ b/ryzen-9-5950x-128gb-docker-zeus-individual-components-tmpfs/8-build-individual-components.24.qtbase.log
@@ -1,0 +1,35 @@
+Loading cache...done.
+Loaded 2448 entries from dependency cache.
+NOTE: Resolving any missing task queue dependencies
+
+Build Configuration:
+BB_VERSION           = "1.44.0"
+BUILD_SYS            = "x86_64-linux"
+NATIVELSBSTRING      = "universal"
+TARGET_SYS           = "x86_64-poky-linux"
+MACHINE              = "qemux86-64"
+DISTRO               = "poky"
+DISTRO_VERSION       = "3.0.2"
+TUNE_FEATURES        = "m64 core2"
+TARGET_FPU           = ""
+meta                 
+meta-poky            
+meta-yocto-bsp       = "zeus:341f87a6ba32f900c744c26d026c5aad6e19c09d"
+meta-browser         = "zeus:1697014a05967ed54b294f3c4b5621df494d6551"
+meta-rust            = "zeus:5d1ada0c97723e1526bf5599b2fa2cbb56c2c0dc"
+meta-oe              = "zeus:e855ecc6d35677e79780adc57b2552213c995731"
+meta-clang           = "zeus:0c393398a91713a108f319ac75337c02b7ebeaa7"
+meta-qt5             = "zeus:a582fd4c810529e9af0c81700407b1955d1391d2"
+
+Initialising tasks...done.
+Sstate summary: Wanted 0 Found 0 Missed 0 Current 138 (0% match, 100% complete)
+NOTE: Executing Tasks
+NOTE: Setscene tasks completed
+NOTE: Running task 1131 of 1132 (/home/yocto/oe-test/test-oe-build-time/poky/meta-qt5/recipes-qt/qt5/qtbase_git.bb:do_configure_ptest_base)
+NOTE: recipe qtbase-5.13.2+gitAUTOINC+a7a24784ee-r0: task do_configure_ptest_base: Started
+NOTE: recipe qtbase-5.13.2+gitAUTOINC+a7a24784ee-r0: task do_configure_ptest_base: Succeeded
+NOTE: Running task 1132 of 1132 (/home/yocto/oe-test/test-oe-build-time/poky/meta-qt5/recipes-qt/qt5/qtbase_git.bb:do_compile)
+NOTE: recipe qtbase-5.13.2+gitAUTOINC+a7a24784ee-r0: task do_compile: Started
+NOTE: recipe qtbase-5.13.2+gitAUTOINC+a7a24784ee-r0: task do_compile: Succeeded
+NOTE: Tasks Summary: Attempted 1132 tasks of which 1130 didn't need to be rerun and all succeeded.
+TIME: 398.73 0.03 0.32 0% 11 12543 9362 0 28008 0 bitbake -c compile qtbase

--- a/ryzen-9-5950x-128gb-docker-zeus-individual-components-tmpfs/8-build-individual-components.24.qtdeclarative.log
+++ b/ryzen-9-5950x-128gb-docker-zeus-individual-components-tmpfs/8-build-individual-components.24.qtdeclarative.log
@@ -1,0 +1,35 @@
+Loading cache...done.
+Loaded 2448 entries from dependency cache.
+NOTE: Resolving any missing task queue dependencies
+
+Build Configuration:
+BB_VERSION           = "1.44.0"
+BUILD_SYS            = "x86_64-linux"
+NATIVELSBSTRING      = "universal"
+TARGET_SYS           = "x86_64-poky-linux"
+MACHINE              = "qemux86-64"
+DISTRO               = "poky"
+DISTRO_VERSION       = "3.0.2"
+TUNE_FEATURES        = "m64 core2"
+TARGET_FPU           = ""
+meta                 
+meta-poky            
+meta-yocto-bsp       = "zeus:341f87a6ba32f900c744c26d026c5aad6e19c09d"
+meta-browser         = "zeus:1697014a05967ed54b294f3c4b5621df494d6551"
+meta-rust            = "zeus:5d1ada0c97723e1526bf5599b2fa2cbb56c2c0dc"
+meta-oe              = "zeus:e855ecc6d35677e79780adc57b2552213c995731"
+meta-clang           = "zeus:0c393398a91713a108f319ac75337c02b7ebeaa7"
+meta-qt5             = "zeus:a582fd4c810529e9af0c81700407b1955d1391d2"
+
+Initialising tasks...done.
+Sstate summary: Wanted 0 Found 0 Missed 0 Current 139 (0% match, 100% complete)
+NOTE: Executing Tasks
+NOTE: Setscene tasks completed
+NOTE: Running task 1143 of 1144 (/home/yocto/oe-test/test-oe-build-time/poky/meta-qt5/recipes-qt/qt5/qtdeclarative_git.bb:do_configure_ptest_base)
+NOTE: recipe qtdeclarative-5.13.2+gitAUTOINC+4080025fed-r0: task do_configure_ptest_base: Started
+NOTE: recipe qtdeclarative-5.13.2+gitAUTOINC+4080025fed-r0: task do_configure_ptest_base: Succeeded
+NOTE: Running task 1144 of 1144 (/home/yocto/oe-test/test-oe-build-time/poky/meta-qt5/recipes-qt/qt5/qtdeclarative_git.bb:do_compile)
+NOTE: recipe qtdeclarative-5.13.2+gitAUTOINC+4080025fed-r0: task do_compile: Started
+NOTE: recipe qtdeclarative-5.13.2+gitAUTOINC+4080025fed-r0: task do_compile: Succeeded
+NOTE: Tasks Summary: Attempted 1144 tasks of which 1142 didn't need to be rerun and all succeeded.
+TIME: 163.57 0.02 0.27 0% 7 12733 9363 0 27936 0 bitbake -c compile qtdeclarative

--- a/ryzen-9-5950x-128gb-docker-zeus-individual-components-tmpfs/8-build-individual-components.24.qtwebengine.log
+++ b/ryzen-9-5950x-128gb-docker-zeus-individual-components-tmpfs/8-build-individual-components.24.qtwebengine.log
@@ -1,0 +1,32 @@
+Loading cache...done.
+Loaded 2448 entries from dependency cache.
+NOTE: Resolving any missing task queue dependencies
+
+Build Configuration:
+BB_VERSION           = "1.44.0"
+BUILD_SYS            = "x86_64-linux"
+NATIVELSBSTRING      = "universal"
+TARGET_SYS           = "x86_64-poky-linux"
+MACHINE              = "qemux86-64"
+DISTRO               = "poky"
+DISTRO_VERSION       = "3.0.2"
+TUNE_FEATURES        = "m64 core2"
+TARGET_FPU           = ""
+meta                 
+meta-poky            
+meta-yocto-bsp       = "zeus:341f87a6ba32f900c744c26d026c5aad6e19c09d"
+meta-browser         = "zeus:1697014a05967ed54b294f3c4b5621df494d6551"
+meta-rust            = "zeus:5d1ada0c97723e1526bf5599b2fa2cbb56c2c0dc"
+meta-oe              = "zeus:e855ecc6d35677e79780adc57b2552213c995731"
+meta-clang           = "zeus:0c393398a91713a108f319ac75337c02b7ebeaa7"
+meta-qt5             = "zeus:a582fd4c810529e9af0c81700407b1955d1391d2"
+
+Initialising tasks...done.
+Sstate summary: Wanted 0 Found 0 Missed 0 Current 195 (0% match, 100% complete)
+NOTE: Executing Tasks
+NOTE: Setscene tasks completed
+NOTE: Running task 1619 of 1619 (/home/yocto/oe-test/test-oe-build-time/poky/meta-qt5/recipes-qt/qt5/qtwebengine_git.bb:do_compile)
+NOTE: recipe qtwebengine-5.13.2+gitAUTOINC+556576b55f_843d70ac87-r0: task do_compile: Started
+NOTE: recipe qtwebengine-5.13.2+gitAUTOINC+556576b55f_843d70ac87-r0: task do_compile: Succeeded
+NOTE: Tasks Summary: Attempted 1619 tasks of which 1618 didn't need to be rerun and all succeeded.
+TIME: 1059.22 0.28 3.09 0% 119 64538 9370 0 28072 0 bitbake -c compile qtwebengine

--- a/ryzen-9-5950x-128gb-docker-zeus-individual-components-tmpfs/8-build-individual-components.24.rust-native.log
+++ b/ryzen-9-5950x-128gb-docker-zeus-individual-components-tmpfs/8-build-individual-components.24.rust-native.log
@@ -1,0 +1,35 @@
+Loading cache...done.
+Loaded 2448 entries from dependency cache.
+NOTE: Resolving any missing task queue dependencies
+
+Build Configuration:
+BB_VERSION           = "1.44.0"
+BUILD_SYS            = "x86_64-linux"
+NATIVELSBSTRING      = "universal"
+TARGET_SYS           = "x86_64-poky-linux"
+MACHINE              = "qemux86-64"
+DISTRO               = "poky"
+DISTRO_VERSION       = "3.0.2"
+TUNE_FEATURES        = "m64 core2"
+TARGET_FPU           = ""
+meta                 
+meta-poky            
+meta-yocto-bsp       = "zeus:341f87a6ba32f900c744c26d026c5aad6e19c09d"
+meta-browser         = "zeus:1697014a05967ed54b294f3c4b5621df494d6551"
+meta-rust            = "zeus:5d1ada0c97723e1526bf5599b2fa2cbb56c2c0dc"
+meta-oe              = "zeus:e855ecc6d35677e79780adc57b2552213c995731"
+meta-clang           = "zeus:0c393398a91713a108f319ac75337c02b7ebeaa7"
+meta-qt5             = "zeus:a582fd4c810529e9af0c81700407b1955d1391d2"
+
+Initialising tasks...done.
+Sstate summary: Wanted 0 Found 0 Missed 0 Current 25 (0% match, 100% complete)
+NOTE: Executing Tasks
+NOTE: Setscene tasks completed
+NOTE: Running task 166 of 210 (virtual:native:/home/yocto/oe-test/test-oe-build-time/poky/meta-rust/recipes-devtools/rust/rust_1.37.0.bb:do_rust_gen_targets)
+NOTE: recipe rust-native-1.37.0-r0: task do_rust_gen_targets: Started
+NOTE: recipe rust-native-1.37.0-r0: task do_rust_gen_targets: Succeeded
+NOTE: Running task 210 of 210 (virtual:native:/home/yocto/oe-test/test-oe-build-time/poky/meta-rust/recipes-devtools/rust/rust_1.37.0.bb:do_compile)
+NOTE: recipe rust-native-1.37.0-r0: task do_compile: Started
+NOTE: recipe rust-native-1.37.0-r0: task do_compile: Succeeded
+NOTE: Tasks Summary: Attempted 210 tasks of which 208 didn't need to be rerun and all succeeded.
+TIME: 1034.00 0.04 0.33 0% 24 12422 9358 0 27932 0 bitbake -c compile rust-native

--- a/ryzen-9-5950x-128gb-docker-zeus-individual-components-tmpfs/8-build-individual-components.32.chromium-x11.log
+++ b/ryzen-9-5950x-128gb-docker-zeus-individual-components-tmpfs/8-build-individual-components.32.chromium-x11.log
@@ -1,0 +1,35 @@
+Loading cache...done.
+Loaded 2448 entries from dependency cache.
+NOTE: Resolving any missing task queue dependencies
+
+Build Configuration:
+BB_VERSION           = "1.44.0"
+BUILD_SYS            = "x86_64-linux"
+NATIVELSBSTRING      = "universal"
+TARGET_SYS           = "x86_64-poky-linux"
+MACHINE              = "qemux86-64"
+DISTRO               = "poky"
+DISTRO_VERSION       = "3.0.2"
+TUNE_FEATURES        = "m64 core2"
+TARGET_FPU           = ""
+meta                 
+meta-poky            
+meta-yocto-bsp       = "zeus:341f87a6ba32f900c744c26d026c5aad6e19c09d"
+meta-browser         = "zeus:1697014a05967ed54b294f3c4b5621df494d6551"
+meta-rust            = "zeus:5d1ada0c97723e1526bf5599b2fa2cbb56c2c0dc"
+meta-oe              = "zeus:e855ecc6d35677e79780adc57b2552213c995731"
+meta-clang           = "zeus:0c393398a91713a108f319ac75337c02b7ebeaa7"
+meta-qt5             = "zeus:a582fd4c810529e9af0c81700407b1955d1391d2"
+
+Initialising tasks...done.
+Sstate summary: Wanted 0 Found 0 Missed 0 Current 232 (0% match, 100% complete)
+NOTE: Executing Tasks
+NOTE: Setscene tasks completed
+NOTE: Running task 1912 of 1913 (/home/yocto/oe-test/test-oe-build-time/poky/meta-browser/recipes-browser/chromium/chromium-x11_79.0.3945.117.bb:do_add_nodejs_symlink)
+NOTE: recipe chromium-x11-79.0.3945.117-r0: task do_add_nodejs_symlink: Started
+NOTE: recipe chromium-x11-79.0.3945.117-r0: task do_add_nodejs_symlink: Succeeded
+NOTE: Running task 1913 of 1913 (/home/yocto/oe-test/test-oe-build-time/poky/meta-browser/recipes-browser/chromium/chromium-x11_79.0.3945.117.bb:do_compile)
+NOTE: recipe chromium-x11-79.0.3945.117-r0: task do_compile: Started
+NOTE: recipe chromium-x11-79.0.3945.117-r0: task do_compile: Succeeded
+NOTE: Tasks Summary: Attempted 1913 tasks of which 1911 didn't need to be rerun and all succeeded.
+TIME: 3120.27 0.68 8.65 0% 631 102861 9365 0 27976 0 bitbake -c compile chromium-x11

--- a/ryzen-9-5950x-128gb-docker-zeus-individual-components-tmpfs/8-build-individual-components.32.qtbase.log
+++ b/ryzen-9-5950x-128gb-docker-zeus-individual-components-tmpfs/8-build-individual-components.32.qtbase.log
@@ -1,0 +1,35 @@
+Loading cache...done.
+Loaded 2448 entries from dependency cache.
+NOTE: Resolving any missing task queue dependencies
+
+Build Configuration:
+BB_VERSION           = "1.44.0"
+BUILD_SYS            = "x86_64-linux"
+NATIVELSBSTRING      = "universal"
+TARGET_SYS           = "x86_64-poky-linux"
+MACHINE              = "qemux86-64"
+DISTRO               = "poky"
+DISTRO_VERSION       = "3.0.2"
+TUNE_FEATURES        = "m64 core2"
+TARGET_FPU           = ""
+meta                 
+meta-poky            
+meta-yocto-bsp       = "zeus:341f87a6ba32f900c744c26d026c5aad6e19c09d"
+meta-browser         = "zeus:1697014a05967ed54b294f3c4b5621df494d6551"
+meta-rust            = "zeus:5d1ada0c97723e1526bf5599b2fa2cbb56c2c0dc"
+meta-oe              = "zeus:e855ecc6d35677e79780adc57b2552213c995731"
+meta-clang           = "zeus:0c393398a91713a108f319ac75337c02b7ebeaa7"
+meta-qt5             = "zeus:a582fd4c810529e9af0c81700407b1955d1391d2"
+
+Initialising tasks...done.
+Sstate summary: Wanted 0 Found 0 Missed 0 Current 138 (0% match, 100% complete)
+NOTE: Executing Tasks
+NOTE: Setscene tasks completed
+NOTE: Running task 1131 of 1132 (/home/yocto/oe-test/test-oe-build-time/poky/meta-qt5/recipes-qt/qt5/qtbase_git.bb:do_configure_ptest_base)
+NOTE: recipe qtbase-5.13.2+gitAUTOINC+a7a24784ee-r0: task do_configure_ptest_base: Started
+NOTE: recipe qtbase-5.13.2+gitAUTOINC+a7a24784ee-r0: task do_configure_ptest_base: Succeeded
+NOTE: Running task 1132 of 1132 (/home/yocto/oe-test/test-oe-build-time/poky/meta-qt5/recipes-qt/qt5/qtbase_git.bb:do_compile)
+NOTE: recipe qtbase-5.13.2+gitAUTOINC+a7a24784ee-r0: task do_compile: Started
+NOTE: recipe qtbase-5.13.2+gitAUTOINC+a7a24784ee-r0: task do_compile: Succeeded
+NOTE: Tasks Summary: Attempted 1132 tasks of which 1130 didn't need to be rerun and all succeeded.
+TIME: 401.87 0.04 0.33 0% 11 13678 9369 0 27988 0 bitbake -c compile qtbase

--- a/ryzen-9-5950x-128gb-docker-zeus-individual-components-tmpfs/8-build-individual-components.32.qtdeclarative.log
+++ b/ryzen-9-5950x-128gb-docker-zeus-individual-components-tmpfs/8-build-individual-components.32.qtdeclarative.log
@@ -1,0 +1,35 @@
+Loading cache...done.
+Loaded 2448 entries from dependency cache.
+NOTE: Resolving any missing task queue dependencies
+
+Build Configuration:
+BB_VERSION           = "1.44.0"
+BUILD_SYS            = "x86_64-linux"
+NATIVELSBSTRING      = "universal"
+TARGET_SYS           = "x86_64-poky-linux"
+MACHINE              = "qemux86-64"
+DISTRO               = "poky"
+DISTRO_VERSION       = "3.0.2"
+TUNE_FEATURES        = "m64 core2"
+TARGET_FPU           = ""
+meta                 
+meta-poky            
+meta-yocto-bsp       = "zeus:341f87a6ba32f900c744c26d026c5aad6e19c09d"
+meta-browser         = "zeus:1697014a05967ed54b294f3c4b5621df494d6551"
+meta-rust            = "zeus:5d1ada0c97723e1526bf5599b2fa2cbb56c2c0dc"
+meta-oe              = "zeus:e855ecc6d35677e79780adc57b2552213c995731"
+meta-clang           = "zeus:0c393398a91713a108f319ac75337c02b7ebeaa7"
+meta-qt5             = "zeus:a582fd4c810529e9af0c81700407b1955d1391d2"
+
+Initialising tasks...done.
+Sstate summary: Wanted 0 Found 0 Missed 0 Current 139 (0% match, 100% complete)
+NOTE: Executing Tasks
+NOTE: Setscene tasks completed
+NOTE: Running task 1143 of 1144 (/home/yocto/oe-test/test-oe-build-time/poky/meta-qt5/recipes-qt/qt5/qtdeclarative_git.bb:do_configure_ptest_base)
+NOTE: recipe qtdeclarative-5.13.2+gitAUTOINC+4080025fed-r0: task do_configure_ptest_base: Started
+NOTE: recipe qtdeclarative-5.13.2+gitAUTOINC+4080025fed-r0: task do_configure_ptest_base: Succeeded
+NOTE: Running task 1144 of 1144 (/home/yocto/oe-test/test-oe-build-time/poky/meta-qt5/recipes-qt/qt5/qtdeclarative_git.bb:do_compile)
+NOTE: recipe qtdeclarative-5.13.2+gitAUTOINC+4080025fed-r0: task do_compile: Started
+NOTE: recipe qtdeclarative-5.13.2+gitAUTOINC+4080025fed-r0: task do_compile: Succeeded
+NOTE: Tasks Summary: Attempted 1144 tasks of which 1142 didn't need to be rerun and all succeeded.
+TIME: 161.31 0.02 0.25 0% 13 11387 9369 0 28024 0 bitbake -c compile qtdeclarative

--- a/ryzen-9-5950x-128gb-docker-zeus-individual-components-tmpfs/8-build-individual-components.32.qtwebengine.log
+++ b/ryzen-9-5950x-128gb-docker-zeus-individual-components-tmpfs/8-build-individual-components.32.qtwebengine.log
@@ -1,0 +1,32 @@
+Loading cache...done.
+Loaded 2448 entries from dependency cache.
+NOTE: Resolving any missing task queue dependencies
+
+Build Configuration:
+BB_VERSION           = "1.44.0"
+BUILD_SYS            = "x86_64-linux"
+NATIVELSBSTRING      = "universal"
+TARGET_SYS           = "x86_64-poky-linux"
+MACHINE              = "qemux86-64"
+DISTRO               = "poky"
+DISTRO_VERSION       = "3.0.2"
+TUNE_FEATURES        = "m64 core2"
+TARGET_FPU           = ""
+meta                 
+meta-poky            
+meta-yocto-bsp       = "zeus:341f87a6ba32f900c744c26d026c5aad6e19c09d"
+meta-browser         = "zeus:1697014a05967ed54b294f3c4b5621df494d6551"
+meta-rust            = "zeus:5d1ada0c97723e1526bf5599b2fa2cbb56c2c0dc"
+meta-oe              = "zeus:e855ecc6d35677e79780adc57b2552213c995731"
+meta-clang           = "zeus:0c393398a91713a108f319ac75337c02b7ebeaa7"
+meta-qt5             = "zeus:a582fd4c810529e9af0c81700407b1955d1391d2"
+
+Initialising tasks...done.
+Sstate summary: Wanted 0 Found 0 Missed 0 Current 195 (0% match, 100% complete)
+NOTE: Executing Tasks
+NOTE: Setscene tasks completed
+NOTE: Running task 1619 of 1619 (/home/yocto/oe-test/test-oe-build-time/poky/meta-qt5/recipes-qt/qt5/qtwebengine_git.bb:do_compile)
+NOTE: recipe qtwebengine-5.13.2+gitAUTOINC+556576b55f_843d70ac87-r0: task do_compile: Started
+NOTE: recipe qtwebengine-5.13.2+gitAUTOINC+556576b55f_843d70ac87-r0: task do_compile: Succeeded
+NOTE: Tasks Summary: Attempted 1619 tasks of which 1618 didn't need to be rerun and all succeeded.
+TIME: 997.65 0.27 2.97 0% 272 50006 9367 0 28016 0 bitbake -c compile qtwebengine

--- a/ryzen-9-5950x-128gb-docker-zeus-individual-components-tmpfs/8-build-individual-components.32.rust-native.log
+++ b/ryzen-9-5950x-128gb-docker-zeus-individual-components-tmpfs/8-build-individual-components.32.rust-native.log
@@ -1,0 +1,35 @@
+Loading cache...done.
+Loaded 2448 entries from dependency cache.
+NOTE: Resolving any missing task queue dependencies
+
+Build Configuration:
+BB_VERSION           = "1.44.0"
+BUILD_SYS            = "x86_64-linux"
+NATIVELSBSTRING      = "universal"
+TARGET_SYS           = "x86_64-poky-linux"
+MACHINE              = "qemux86-64"
+DISTRO               = "poky"
+DISTRO_VERSION       = "3.0.2"
+TUNE_FEATURES        = "m64 core2"
+TARGET_FPU           = ""
+meta                 
+meta-poky            
+meta-yocto-bsp       = "zeus:341f87a6ba32f900c744c26d026c5aad6e19c09d"
+meta-browser         = "zeus:1697014a05967ed54b294f3c4b5621df494d6551"
+meta-rust            = "zeus:5d1ada0c97723e1526bf5599b2fa2cbb56c2c0dc"
+meta-oe              = "zeus:e855ecc6d35677e79780adc57b2552213c995731"
+meta-clang           = "zeus:0c393398a91713a108f319ac75337c02b7ebeaa7"
+meta-qt5             = "zeus:a582fd4c810529e9af0c81700407b1955d1391d2"
+
+Initialising tasks...done.
+Sstate summary: Wanted 0 Found 0 Missed 0 Current 25 (0% match, 100% complete)
+NOTE: Executing Tasks
+NOTE: Setscene tasks completed
+NOTE: Running task 166 of 210 (virtual:native:/home/yocto/oe-test/test-oe-build-time/poky/meta-rust/recipes-devtools/rust/rust_1.37.0.bb:do_rust_gen_targets)
+NOTE: recipe rust-native-1.37.0-r0: task do_rust_gen_targets: Started
+NOTE: recipe rust-native-1.37.0-r0: task do_rust_gen_targets: Succeeded
+NOTE: Running task 210 of 210 (virtual:native:/home/yocto/oe-test/test-oe-build-time/poky/meta-rust/recipes-devtools/rust/rust_1.37.0.bb:do_compile)
+NOTE: recipe rust-native-1.37.0-r0: task do_compile: Started
+NOTE: recipe rust-native-1.37.0-r0: task do_compile: Succeeded
+NOTE: Tasks Summary: Attempted 210 tasks of which 208 didn't need to be rerun and all succeeded.
+TIME: 1027.47 0.02 0.34 0% 20 12463 9354 0 28008 0 bitbake -c compile rust-native

--- a/ryzen-9-5950x-128gb-docker-zeus-individual-components-tmpfs/lshw.txt
+++ b/ryzen-9-5950x-128gb-docker-zeus-individual-components-tmpfs/lshw.txt
@@ -1,0 +1,945 @@
+nova
+    description: Desktop Computer
+    product: System Product Name (SKU)
+    vendor: ASUS
+    version: System Version
+    serial: System Serial Number
+    width: 4294967295 bits
+    capabilities: smbios-3.3 dmi-3.3 smp vsyscall32
+    configuration: boot=normal chassis=desktop family=To be filled by O.E.M. sku=SKU uuid=C3589B36-244B-FE52-CB06-244BFE52CB05
+  *-core
+       description: Motherboard
+       product: ROG CROSSHAIR VIII HERO
+       vendor: ASUSTeK COMPUTER INC.
+       physical id: 0
+       version: Rev X.0x
+       serial: 200670636500635
+       slot: Default string
+     *-firmware
+          description: BIOS
+          vendor: American Megatrends Inc.
+          physical id: 0
+          version: 3204
+          date: 01/25/2021
+          size: 64KiB
+          capacity: 15MiB
+          capabilities: pci apm upgrade shadowing cdboot bootselect socketedrom edd int13floppy1200 int13floppy720 int13floppy2880 int5printscreen int9keyboard int14serial int17printer acpi usb biosbootspecification uefi
+     *-memory
+          description: System Memory
+          physical id: 3a
+          slot: System board or motherboard
+          size: 128GiB
+        *-bank:0
+             description: DIMM DDR4 Synchronous Unbuffered (Unregistered) 3600 MHz (0,3 ns)
+             product: BL32G36C16U4B.M16FB1
+             vendor: Crucial Technology
+             physical id: 0
+             serial: E3958BA2
+             slot: DIMM_A1
+             size: 32GiB
+             width: 64 bits
+             clock: 3600MHz (0.3ns)
+        *-bank:1
+             description: DIMM DDR4 Synchronous Unbuffered (Unregistered) 3600 MHz (0,3 ns)
+             product: BL32G36C16U4B.M16FB1
+             vendor: Crucial Technology
+             physical id: 1
+             serial: E3958AE8
+             slot: DIMM_A2
+             size: 32GiB
+             width: 64 bits
+             clock: 3600MHz (0.3ns)
+        *-bank:2
+             description: DIMM DDR4 Synchronous Unbuffered (Unregistered) 3600 MHz (0,3 ns)
+             product: BL32G36C16U4B.M16FB1
+             vendor: Crucial Technology
+             physical id: 2
+             serial: E3958D79
+             slot: DIMM_B1
+             size: 32GiB
+             width: 64 bits
+             clock: 3600MHz (0.3ns)
+        *-bank:3
+             description: DIMM DDR4 Synchronous Unbuffered (Unregistered) 3600 MHz (0,3 ns)
+             product: BL32G36C16U4B.M16FB1
+             vendor: Crucial Technology
+             physical id: 3
+             serial: E3958CAA
+             slot: DIMM_B2
+             size: 32GiB
+             width: 64 bits
+             clock: 3600MHz (0.3ns)
+     *-cache:0
+          description: L1 cache
+          physical id: 3d
+          slot: L1 - Cache
+          size: 1MiB
+          capacity: 1MiB
+          clock: 1GHz (1.0ns)
+          capabilities: pipeline-burst internal write-back unified
+          configuration: level=1
+     *-cache:1
+          description: L2 cache
+          physical id: 3e
+          slot: L2 - Cache
+          size: 8MiB
+          capacity: 8MiB
+          clock: 1GHz (1.0ns)
+          capabilities: pipeline-burst internal write-back unified
+          configuration: level=2
+     *-cache:2
+          description: L3 cache
+          physical id: 3f
+          slot: L3 - Cache
+          size: 64MiB
+          capacity: 64MiB
+          clock: 1GHz (1.0ns)
+          capabilities: pipeline-burst internal write-back unified
+          configuration: level=3
+     *-cpu
+          description: CPU
+          product: AMD Ryzen 9 5950X 16-Core Processor
+          vendor: Advanced Micro Devices [AMD]
+          physical id: 40
+          bus info: cpu@0
+          version: AMD Ryzen 9 5950X 16-Core Processor
+          serial: Unknown
+          slot: AM4
+          size: 4640MHz
+          width: 64 bits
+          clock: 100MHz
+          capabilities: x86-64 fpu fpu_exception wp vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp constant_tsc rep_good nopl nonstop_tsc cpuid extd_apicid aperfmperf pni pclmulqdq monitor ssse3 fma cx16 sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand lahf_lm cmp_legacy svm extapic cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw ibs skinit wdt tce topoext perfctr_core perfctr_nb bpext perfctr_llc mwaitx cpb cat_l3 cdp_l3 hw_pstate ssbd mba ibrs ibpb stibp vmmcall fsgsbase bmi1 avx2 smep bmi2 erms invpcid cqm rdt_a rdseed adx smap clflushopt clwb sha_ni xsaveopt xsavec xgetbv1 xsaves cqm_llc cqm_occup_llc cqm_mbm_total cqm_mbm_local clzero irperf xsaveerptr rdpru wbnoinvd arat npt lbrv svm_lock nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold avic v_vmsave_vmload vgif umip pku ospke vaes vpclmulqdq rdpid overflow_recov succor smca fsrm cpufreq
+          configuration: cores=16 enabledcores=16 threads=32
+     *-pci:0
+          description: Host bridge
+          product: Starship/Matisse Root Complex
+          vendor: Advanced Micro Devices, Inc. [AMD]
+          physical id: 100
+          bus info: pci@0000:00:00.0
+          version: 00
+          width: 32 bits
+          clock: 33MHz
+        *-generic UNCLAIMED
+             description: IOMMU
+             product: Starship/Matisse IOMMU
+             vendor: Advanced Micro Devices, Inc. [AMD]
+             physical id: 0.2
+             bus info: pci@0000:00:00.2
+             version: 00
+             width: 32 bits
+             clock: 33MHz
+             capabilities: msi ht cap_list
+             configuration: latency=0
+        *-pci:0
+             description: PCI bridge
+             product: Starship/Matisse GPP Bridge
+             vendor: Advanced Micro Devices, Inc. [AMD]
+             physical id: 1.1
+             bus info: pci@0000:00:01.1
+             version: 00
+             width: 32 bits
+             clock: 33MHz
+             capabilities: pci pm pciexpress msi ht normal_decode bus_master cap_list
+             configuration: driver=pcieport
+             resources: irq:27 memory:fcf00000-fcffffff
+           *-storage
+                description: Non-Volatile memory controller
+                product: E16 PCIe4 NVMe Controller
+                vendor: Phison Electronics Corporation
+                physical id: 0
+                bus info: pci@0000:01:00.0
+                version: 01
+                width: 64 bits
+                clock: 33MHz
+                capabilities: storage pciexpress msix msi pm nvm_express bus_master cap_list
+                configuration: driver=nvme latency=0
+                resources: irq:42 memory:fcf00000-fcf03fff
+        *-pci:1
+             description: PCI bridge
+             product: Starship/Matisse GPP Bridge
+             vendor: Advanced Micro Devices, Inc. [AMD]
+             physical id: 1.2
+             bus info: pci@0000:00:01.2
+             version: 00
+             width: 32 bits
+             clock: 33MHz
+             capabilities: pci pm pciexpress msi ht normal_decode bus_master cap_list
+             configuration: driver=pcieport
+             resources: irq:28 ioport:d000(size=8192) memory:fc500000-fcafffff
+           *-pci
+                description: PCI bridge
+                product: Matisse Switch Upstream
+                vendor: Advanced Micro Devices, Inc. [AMD]
+                physical id: 0
+                bus info: pci@0000:02:00.0
+                version: 00
+                width: 32 bits
+                clock: 33MHz
+                capabilities: pci pm pciexpress msi normal_decode bus_master cap_list
+                configuration: driver=pcieport
+                resources: irq:24 ioport:d000(size=8192) memory:fc500000-fcafffff
+              *-pci:0
+                   description: PCI bridge
+                   product: Matisse PCIe GPP Bridge
+                   vendor: Advanced Micro Devices, Inc. [AMD]
+                   physical id: 3
+                   bus info: pci@0000:03:03.0
+                   version: 00
+                   width: 32 bits
+                   clock: 33MHz
+                   capabilities: pci pm pciexpress msi ht normal_decode bus_master cap_list
+                   configuration: driver=pcieport
+                   resources: irq:33 ioport:e000(size=4096) memory:fca00000-fcafffff
+                 *-network
+                      description: Ethernet interface
+                      product: RTL8125 2.5GbE Controller
+                      vendor: Realtek Semiconductor Co., Ltd.
+                      physical id: 0
+                      bus info: pci@0000:04:00.0
+                      logical name: enp4s0
+                      version: 00
+                      serial: 24:4b:fe:52:cb:06
+                      capacity: 1Gbit/s
+                      width: 64 bits
+                      clock: 33MHz
+                      capabilities: pm msi pciexpress msix vpd bus_master cap_list rom ethernet physical tp mii 10bt 10bt-fd 100bt 100bt-fd 1000bt-fd autonegotiation
+                      configuration: autonegotiation=on broadcast=yes driver=r8169 driverversion=5.10.27-gentoo-FrostEyes firmware=rtl8125a-3_0.0.1 08/24/19 latency=0 link=no multicast=yes port=twisted pair
+                      resources: irq:59 ioport:e000(size=256) memory:fca10000-fca1ffff memory:fca20000-fca23fff memory:fca00000-fca0ffff memory:fca30000-fca9ffff memory:fcaa0000-fcabbfff
+              *-pci:1
+                   description: PCI bridge
+                   product: Matisse PCIe GPP Bridge
+                   vendor: Advanced Micro Devices, Inc. [AMD]
+                   physical id: 5
+                   bus info: pci@0000:03:05.0
+                   version: 00
+                   width: 32 bits
+                   clock: 33MHz
+                   capabilities: pci pm pciexpress msi ht normal_decode bus_master cap_list
+                   configuration: driver=pcieport
+                   resources: irq:34 ioport:d000(size=4096) memory:fc900000-fc9fffff
+                 *-network
+                      description: Ethernet interface
+                      product: I211 Gigabit Network Connection
+                      vendor: Intel Corporation
+                      physical id: 0
+                      bus info: pci@0000:05:00.0
+                      logical name: enp5s0
+                      version: 03
+                      serial: 24:4b:fe:52:cb:05
+                      size: 1Gbit/s
+                      capacity: 1Gbit/s
+                      width: 32 bits
+                      clock: 33MHz
+                      capabilities: pm msi msix pciexpress bus_master cap_list ethernet physical tp 10bt 10bt-fd 100bt 100bt-fd 1000bt-fd autonegotiation
+                      configuration: autonegotiation=on broadcast=yes driver=igb driverversion=5.10.27-gentoo-FrostEyes duplex=full firmware=0. 6-1 ip=192.168.1.70 latency=0 link=yes multicast=yes port=twisted pair speed=1Gbit/s
+                      resources: irq:36 memory:fc900000-fc91ffff ioport:d000(size=32) memory:fc920000-fc923fff
+              *-pci:2
+                   description: PCI bridge
+                   product: Matisse PCIe GPP Bridge
+                   vendor: Advanced Micro Devices, Inc. [AMD]
+                   physical id: 8
+                   bus info: pci@0000:03:08.0
+                   version: 00
+                   width: 32 bits
+                   clock: 33MHz
+                   capabilities: pci pm pciexpress msi ht normal_decode bus_master cap_list
+                   configuration: driver=pcieport
+                   resources: irq:35 memory:fc500000-fc6fffff
+                 *-generic UNCLAIMED
+                      description: Non-Essential Instrumentation
+                      product: Starship/Matisse Reserved SPP
+                      vendor: Advanced Micro Devices, Inc. [AMD]
+                      physical id: 0
+                      bus info: pci@0000:06:00.0
+                      version: 00
+                      width: 32 bits
+                      clock: 33MHz
+                      capabilities: pm pciexpress cap_list
+                      configuration: latency=0
+                 *-usb:0
+                      description: USB controller
+                      product: Matisse USB 3.0 Host Controller
+                      vendor: Advanced Micro Devices, Inc. [AMD]
+                      physical id: 0.1
+                      bus info: pci@0000:06:00.1
+                      version: 00
+                      width: 64 bits
+                      clock: 33MHz
+                      capabilities: pm pciexpress msi xhci bus_master cap_list
+                      configuration: driver=xhci_hcd latency=0
+                      resources: irq:61 memory:fc600000-fc6fffff
+                    *-usbhost:0
+                         product: xHCI Host Controller
+                         vendor: Linux 5.10.27-gentoo-FrostEyes xhci-hcd
+                         physical id: 0
+                         bus info: usb@1
+                         logical name: usb1
+                         version: 5.10
+                         capabilities: usb-2.00
+                         configuration: driver=hub slots=6 speed=480Mbit/s
+                       *-usb
+                            description: USB hub
+                            product: USB2.0 Hub
+                            vendor: Genesys Logic, Inc.
+                            physical id: 5
+                            bus info: usb@1:5
+                            version: 32.98
+                            capabilities: usb-2.00
+                            configuration: driver=hub maxpower=100mA slots=4 speed=480Mbit/s
+                          *-usb
+                               description: Human interface device
+                               product: AURA LED Controller
+                               vendor: AsusTek Computer Inc.
+                               physical id: 3
+                               bus info: usb@1:5.3
+                               version: 1.00
+                               serial: 9876543210
+                               capabilities: usb-2.00
+                               configuration: driver=usbhid maxpower=16mA speed=12Mbit/s
+                    *-usbhost:1
+                         product: xHCI Host Controller
+                         vendor: Linux 5.10.27-gentoo-FrostEyes xhci-hcd
+                         physical id: 1
+                         bus info: usb@2
+                         logical name: usb2
+                         version: 5.10
+                         capabilities: usb-3.10
+                         configuration: driver=hub slots=4 speed=10000Mbit/s
+                 *-usb:1
+                      description: USB controller
+                      product: Matisse USB 3.0 Host Controller
+                      vendor: Advanced Micro Devices, Inc. [AMD]
+                      physical id: 0.3
+                      bus info: pci@0000:06:00.3
+                      version: 00
+                      width: 64 bits
+                      clock: 33MHz
+                      capabilities: pm pciexpress msi msix xhci bus_master cap_list
+                      configuration: driver=xhci_hcd latency=0
+                      resources: irq:38 memory:fc500000-fc5fffff
+                    *-usbhost:0
+                         product: xHCI Host Controller
+                         vendor: Linux 5.10.27-gentoo-FrostEyes xhci-hcd
+                         physical id: 0
+                         bus info: usb@3
+                         logical name: usb3
+                         version: 5.10
+                         capabilities: usb-2.00
+                         configuration: driver=hub slots=6 speed=480Mbit/s
+                       *-usb
+                            description: USB hub
+                            product: ASM107x
+                            vendor: ASUS TEK.
+                            physical id: 2
+                            bus info: usb@3:2
+                            version: 0.01
+                            capabilities: usb-2.10
+                            configuration: driver=hub maxpower=100mA slots=4 speed=480Mbit/s
+                          *-usb:0
+                               description: USB hub
+                               product: TUSB8041 4-Port Hub
+                               vendor: Texas Instruments, Inc.
+                               physical id: 1
+                               bus info: usb@3:2.1
+                               version: 1.00
+                               serial: 2901006924FF
+                               capabilities: usb-2.10
+                               configuration: driver=hub slots=4 speed=480Mbit/s
+                             *-usb:0
+                                  description: Mouse
+                                  product: USB-PS/2 Optical Mouse
+                                  vendor: Logitech
+                                  physical id: 1
+                                  bus info: usb@3:2.1.1
+                                  version: 27.20
+                                  capabilities: usb-2.00
+                                  configuration: driver=usbhid maxpower=98mA speed=1Mbit/s
+                             *-usb:1
+                                  description: Keyboard
+                                  product: USB Keyboard
+                                  vendor: Logitech
+                                  physical id: 2
+                                  bus info: usb@3:2.1.2
+                                  version: 86.00
+                                  capabilities: usb-1.10
+                                  configuration: driver=usbhid maxpower=98mA speed=1Mbit/s
+                             *-usb:2
+                                  description: USB hub
+                                  product: TUSB8041 4-Port Hub
+                                  vendor: Texas Instruments, Inc.
+                                  physical id: 3
+                                  bus info: usb@3:2.1.3
+                                  version: 1.00
+                                  serial: 3901006924FF
+                                  capabilities: usb-2.10
+                                  configuration: driver=hub slots=4 speed=480Mbit/s
+                                *-usb
+                                     description: USB hub
+                                     product: USB2.1 Hub
+                                     vendor: GenesysLogic
+                                     physical id: 1
+                                     bus info: usb@3:2.1.3.1
+                                     version: 93.07
+                                     capabilities: usb-2.10
+                                     configuration: driver=hub maxpower=100mA slots=4 speed=480Mbit/s
+                                   *-usb
+                                        description: USB hub
+                                        product: USB2.1 Hub
+                                        vendor: GenesysLogic
+                                        physical id: 4
+                                        bus info: usb@3:2.1.3.1.4
+                                        version: 93.07
+                                        capabilities: usb-2.10
+                                        configuration: driver=hub maxpower=100mA slots=4 speed=480Mbit/s
+                                      *-usb
+                                           description: Generic USB device
+                                           product: TTL232R-3V3
+                                           vendor: FTDI
+                                           physical id: 1
+                                           bus info: usb@3:2.1.3.1.4.1
+                                           version: 6.00
+                                           serial: FT9PNO6D
+                                           capabilities: usb-2.00
+                                           configuration: driver=ftdi_sio maxpower=90mA speed=12Mbit/s
+                             *-usb:3
+                                  description: Human interface device
+                                  product: Texas Instruments USBtoI2C Solution
+                                  vendor: Texas Instruments
+                                  physical id: 4
+                                  bus info: usb@3:2.1.4
+                                  version: 1.00
+                                  capabilities: usb-1.10
+                                  configuration: driver=usbhid maxpower=100mA speed=12Mbit/s
+                          *-usb:1
+                               description: USB hub
+                               product: TUSB8041 4-Port Hub
+                               vendor: Texas Instruments, Inc.
+                               physical id: 2
+                               bus info: usb@3:2.2
+                               version: 1.00
+                               serial: 630A08615820
+                               capabilities: usb-2.10
+                               configuration: driver=hub slots=4 speed=480Mbit/s
+                             *-usb:0
+                                  description: USB hub
+                                  product: TUSB8041 4-Port Hub
+                                  vendor: Texas Instruments, Inc.
+                                  physical id: 3
+                                  bus info: usb@3:2.2.3
+                                  version: 1.00
+                                  serial: 930A00715820
+                                  capabilities: usb-2.10
+                                  configuration: driver=hub slots=4 speed=480Mbit/s
+                             *-usb:1
+                                  description: Human interface device
+                                  product: Texas Instruments USBtoI2C Solution
+                                  vendor: Texas Instruments
+                                  physical id: 4
+                                  bus info: usb@3:2.2.4
+                                  version: 1.00
+                                  capabilities: usb-1.10
+                                  configuration: driver=usbhid maxpower=100mA speed=12Mbit/s
+                    *-usbhost:1
+                         product: xHCI Host Controller
+                         vendor: Linux 5.10.27-gentoo-FrostEyes xhci-hcd
+                         physical id: 1
+                         bus info: usb@4
+                         logical name: usb4
+                         version: 5.10
+                         capabilities: usb-3.10
+                         configuration: driver=hub slots=4 speed=10000Mbit/s
+                       *-usb
+                            description: USB hub
+                            product: ASM107x
+                            vendor: ASUS TEK.
+                            physical id: 2
+                            bus info: usb@4:2
+                            version: 0.01
+                            capabilities: usb-3.00
+                            configuration: driver=hub maxpower=8mA slots=4 speed=5000Mbit/s
+                          *-usb
+                               description: USB hub
+                               product: TUSB8041 4-Port Hub
+                               vendor: Texas Instruments, Inc.
+                               physical id: 1
+                               bus info: usb@4:2.1
+                               version: 1.00
+                               capabilities: usb-3.00
+                               configuration: driver=hub slots=4 speed=5000Mbit/s
+                             *-usb
+                                  description: USB hub
+                                  product: TUSB8041 4-Port Hub
+                                  vendor: Texas Instruments, Inc.
+                                  physical id: 3
+                                  bus info: usb@4:2.1.3
+                                  version: 1.00
+                                  capabilities: usb-3.00
+                                  configuration: driver=hub slots=4 speed=5000Mbit/s
+                                *-usb
+                                     description: USB hub
+                                     product: USB3.2 Hub
+                                     vendor: GenesysLogic
+                                     physical id: 1
+                                     bus info: usb@4:2.1.3.1
+                                     version: 93.07
+                                     capabilities: usb-3.20
+                                     configuration: driver=hub slots=4 speed=5000Mbit/s
+                                   *-usb
+                                        description: USB hub
+                                        product: USB3.2 Hub
+                                        vendor: GenesysLogic
+                                        physical id: 4
+                                        bus info: usb@4:2.1.3.1.4
+                                        version: 93.07
+                                        capabilities: usb-3.20
+                                        configuration: driver=hub slots=4 speed=5000Mbit/s
+              *-pci:3
+                   description: PCI bridge
+                   product: Matisse PCIe GPP Bridge
+                   vendor: Advanced Micro Devices, Inc. [AMD]
+                   physical id: 9
+                   bus info: pci@0000:03:09.0
+                   version: 00
+                   width: 32 bits
+                   clock: 33MHz
+                   capabilities: pci pm pciexpress msi ht normal_decode bus_master cap_list
+                   configuration: driver=pcieport
+                   resources: irq:37 memory:fc800000-fc8fffff
+                 *-storage
+                      description: SATA controller
+                      product: FCH SATA Controller [AHCI mode]
+                      vendor: Advanced Micro Devices, Inc. [AMD]
+                      physical id: 0
+                      bus info: pci@0000:07:00.0
+                      version: 51
+                      width: 32 bits
+                      clock: 33MHz
+                      capabilities: storage pm pciexpress msi ahci_1.0 bus_master cap_list
+                      configuration: driver=ahci latency=0
+                      resources: irq:44 memory:fc800000-fc8007ff
+              *-pci:4
+                   description: PCI bridge
+                   product: Matisse PCIe GPP Bridge
+                   vendor: Advanced Micro Devices, Inc. [AMD]
+                   physical id: a
+                   bus info: pci@0000:03:0a.0
+                   version: 00
+                   width: 32 bits
+                   clock: 33MHz
+                   capabilities: pci pm pciexpress msi ht normal_decode bus_master cap_list
+                   configuration: driver=pcieport
+                   resources: irq:39 memory:fc700000-fc7fffff
+                 *-storage
+                      description: SATA controller
+                      product: FCH SATA Controller [AHCI mode]
+                      vendor: Advanced Micro Devices, Inc. [AMD]
+                      physical id: 0
+                      bus info: pci@0000:08:00.0
+                      version: 51
+                      width: 32 bits
+                      clock: 33MHz
+                      capabilities: storage pm pciexpress msi ahci_1.0 bus_master cap_list
+                      configuration: driver=ahci latency=0
+                      resources: irq:45 memory:fc700000-fc7007ff
+        *-pci:2
+             description: PCI bridge
+             product: Starship/Matisse GPP Bridge
+             vendor: Advanced Micro Devices, Inc. [AMD]
+             physical id: 3.1
+             bus info: pci@0000:00:03.1
+             version: 00
+             width: 32 bits
+             clock: 33MHz
+             capabilities: pci pm pciexpress msi ht normal_decode bus_master cap_list
+             configuration: driver=pcieport
+             resources: irq:29 ioport:f000(size=4096) memory:fce00000-fcefffff ioport:d0000000(size=270532608)
+           *-display
+                description: VGA compatible controller
+                product: Ellesmere [Radeon RX 470/480/570/570X/580/580X/590]
+                vendor: Advanced Micro Devices, Inc. [AMD/ATI]
+                physical id: 0
+                bus info: pci@0000:09:00.0
+                version: ef
+                width: 64 bits
+                clock: 33MHz
+                capabilities: pm pciexpress msi vga_controller bus_master cap_list rom
+                configuration: driver=amdgpu latency=0
+                resources: irq:41 memory:d0000000-dfffffff memory:e0000000-e01fffff ioport:f000(size=256) memory:fce00000-fce3ffff memory:fce40000-fce5ffff
+           *-multimedia
+                description: Audio device
+                product: Ellesmere HDMI Audio [Radeon RX 470/480 / 570/580/590]
+                vendor: Advanced Micro Devices, Inc. [AMD/ATI]
+                physical id: 0.1
+                bus info: pci@0000:09:00.1
+                version: 00
+                width: 64 bits
+                clock: 33MHz
+                capabilities: pm pciexpress msi bus_master cap_list
+                configuration: driver=snd_hda_intel latency=0
+                resources: irq:80 memory:fce60000-fce63fff
+        *-pci:3
+             description: PCI bridge
+             product: Starship/Matisse Internal PCIe GPP Bridge 0 to bus[E:B]
+             vendor: Advanced Micro Devices, Inc. [AMD]
+             physical id: 7.1
+             bus info: pci@0000:00:07.1
+             version: 00
+             width: 32 bits
+             clock: 33MHz
+             capabilities: pci pm pciexpress msi ht normal_decode bus_master cap_list
+             configuration: driver=pcieport
+             resources: irq:31
+           *-generic UNCLAIMED
+                description: Non-Essential Instrumentation
+                product: Starship/Matisse PCIe Dummy Function
+                vendor: Advanced Micro Devices, Inc. [AMD]
+                physical id: 0
+                bus info: pci@0000:0a:00.0
+                version: 00
+                width: 32 bits
+                clock: 33MHz
+                capabilities: pm pciexpress cap_list
+                configuration: latency=0
+        *-pci:4
+             description: PCI bridge
+             product: Starship/Matisse Internal PCIe GPP Bridge 0 to bus[E:B]
+             vendor: Advanced Micro Devices, Inc. [AMD]
+             physical id: 8.1
+             bus info: pci@0000:00:08.1
+             version: 00
+             width: 32 bits
+             clock: 33MHz
+             capabilities: pci pm pciexpress msi ht normal_decode bus_master cap_list
+             configuration: driver=pcieport
+             resources: irq:32 memory:fcb00000-fcdfffff
+           *-generic:0 UNCLAIMED
+                description: Non-Essential Instrumentation
+                product: Starship/Matisse Reserved SPP
+                vendor: Advanced Micro Devices, Inc. [AMD]
+                physical id: 0
+                bus info: pci@0000:0b:00.0
+                version: 00
+                width: 32 bits
+                clock: 33MHz
+                capabilities: pm pciexpress cap_list
+                configuration: latency=0
+           *-generic:1 UNCLAIMED
+                description: Encryption controller
+                product: Starship/Matisse Cryptographic Coprocessor PSPCPP
+                vendor: Advanced Micro Devices, Inc. [AMD]
+                physical id: 0.1
+                bus info: pci@0000:0b:00.1
+                version: 00
+                width: 32 bits
+                clock: 33MHz
+                capabilities: pm pciexpress msi msix cap_list
+                configuration: latency=0
+                resources: memory:fcc00000-fccfffff memory:fcd08000-fcd09fff
+           *-usb
+                description: USB controller
+                product: Matisse USB 3.0 Host Controller
+                vendor: Advanced Micro Devices, Inc. [AMD]
+                physical id: 0.3
+                bus info: pci@0000:0b:00.3
+                version: 00
+                width: 64 bits
+                clock: 33MHz
+                capabilities: pm pciexpress msi msix xhci bus_master cap_list
+                configuration: driver=xhci_hcd latency=0
+                resources: irq:70 memory:fcb00000-fcbfffff
+              *-usbhost:0
+                   product: xHCI Host Controller
+                   vendor: Linux 5.10.27-gentoo-FrostEyes xhci-hcd
+                   physical id: 0
+                   bus info: usb@5
+                   logical name: usb5
+                   version: 5.10
+                   capabilities: usb-2.00
+                   configuration: driver=hub slots=4 speed=480Mbit/s
+              *-usbhost:1
+                   product: xHCI Host Controller
+                   vendor: Linux 5.10.27-gentoo-FrostEyes xhci-hcd
+                   physical id: 1
+                   bus info: usb@6
+                   logical name: usb6
+                   version: 5.10
+                   capabilities: usb-3.10
+                   configuration: driver=hub slots=4 speed=10000Mbit/s
+           *-multimedia
+                description: Audio device
+                product: Starship/Matisse HD Audio Controller
+                vendor: Advanced Micro Devices, Inc. [AMD]
+                physical id: 0.4
+                bus info: pci@0000:0b:00.4
+                version: 00
+                width: 32 bits
+                clock: 33MHz
+                capabilities: pm pciexpress msi bus_master cap_list
+                configuration: driver=snd_hda_intel latency=0
+                resources: irq:82 memory:fcd00000-fcd07fff
+        *-serial UNCLAIMED
+             description: SMBus
+             product: FCH SMBus Controller
+             vendor: Advanced Micro Devices, Inc. [AMD]
+             physical id: 14
+             bus info: pci@0000:00:14.0
+             version: 61
+             width: 32 bits
+             clock: 66MHz
+             configuration: latency=0
+        *-isa
+             description: ISA bridge
+             product: FCH LPC Bridge
+             vendor: Advanced Micro Devices, Inc. [AMD]
+             physical id: 14.3
+             bus info: pci@0000:00:14.3
+             version: 51
+             width: 32 bits
+             clock: 66MHz
+             capabilities: isa bus_master
+             configuration: latency=0
+     *-pci:1
+          description: Host bridge
+          product: Starship/Matisse PCIe Dummy Host Bridge
+          vendor: Advanced Micro Devices, Inc. [AMD]
+          physical id: 101
+          bus info: pci@0000:00:01.0
+          version: 00
+          width: 32 bits
+          clock: 33MHz
+     *-pci:2
+          description: Host bridge
+          product: Starship/Matisse PCIe Dummy Host Bridge
+          vendor: Advanced Micro Devices, Inc. [AMD]
+          physical id: 102
+          bus info: pci@0000:00:02.0
+          version: 00
+          width: 32 bits
+          clock: 33MHz
+     *-pci:3
+          description: Host bridge
+          product: Starship/Matisse PCIe Dummy Host Bridge
+          vendor: Advanced Micro Devices, Inc. [AMD]
+          physical id: 103
+          bus info: pci@0000:00:03.0
+          version: 00
+          width: 32 bits
+          clock: 33MHz
+     *-pci:4
+          description: Host bridge
+          product: Starship/Matisse PCIe Dummy Host Bridge
+          vendor: Advanced Micro Devices, Inc. [AMD]
+          physical id: 104
+          bus info: pci@0000:00:04.0
+          version: 00
+          width: 32 bits
+          clock: 33MHz
+     *-pci:5
+          description: Host bridge
+          product: Starship/Matisse PCIe Dummy Host Bridge
+          vendor: Advanced Micro Devices, Inc. [AMD]
+          physical id: 105
+          bus info: pci@0000:00:05.0
+          version: 00
+          width: 32 bits
+          clock: 33MHz
+     *-pci:6
+          description: Host bridge
+          product: Starship/Matisse PCIe Dummy Host Bridge
+          vendor: Advanced Micro Devices, Inc. [AMD]
+          physical id: 106
+          bus info: pci@0000:00:07.0
+          version: 00
+          width: 32 bits
+          clock: 33MHz
+     *-pci:7
+          description: Host bridge
+          product: Starship/Matisse PCIe Dummy Host Bridge
+          vendor: Advanced Micro Devices, Inc. [AMD]
+          physical id: 107
+          bus info: pci@0000:00:08.0
+          version: 00
+          width: 32 bits
+          clock: 33MHz
+     *-pci:8
+          description: Host bridge
+          product: Matisse Device 24: Function 0
+          vendor: Advanced Micro Devices, Inc. [AMD]
+          physical id: 108
+          bus info: pci@0000:00:18.0
+          version: 00
+          width: 32 bits
+          clock: 33MHz
+     *-pci:9
+          description: Host bridge
+          product: Matisse Device 24: Function 1
+          vendor: Advanced Micro Devices, Inc. [AMD]
+          physical id: 109
+          bus info: pci@0000:00:18.1
+          version: 00
+          width: 32 bits
+          clock: 33MHz
+     *-pci:10
+          description: Host bridge
+          product: Matisse Device 24: Function 2
+          vendor: Advanced Micro Devices, Inc. [AMD]
+          physical id: 10a
+          bus info: pci@0000:00:18.2
+          version: 00
+          width: 32 bits
+          clock: 33MHz
+     *-pci:11
+          description: Host bridge
+          product: Matisse Device 24: Function 3
+          vendor: Advanced Micro Devices, Inc. [AMD]
+          physical id: 10b
+          bus info: pci@0000:00:18.3
+          version: 00
+          width: 32 bits
+          clock: 33MHz
+          configuration: driver=k10temp
+          resources: irq:0
+     *-pci:12
+          description: Host bridge
+          product: Matisse Device 24: Function 4
+          vendor: Advanced Micro Devices, Inc. [AMD]
+          physical id: 10c
+          bus info: pci@0000:00:18.4
+          version: 00
+          width: 32 bits
+          clock: 33MHz
+     *-pci:13
+          description: Host bridge
+          product: Matisse Device 24: Function 5
+          vendor: Advanced Micro Devices, Inc. [AMD]
+          physical id: 10d
+          bus info: pci@0000:00:18.5
+          version: 00
+          width: 32 bits
+          clock: 33MHz
+     *-pci:14
+          description: Host bridge
+          product: Matisse Device 24: Function 6
+          vendor: Advanced Micro Devices, Inc. [AMD]
+          physical id: 10e
+          bus info: pci@0000:00:18.6
+          version: 00
+          width: 32 bits
+          clock: 33MHz
+     *-pci:15
+          description: Host bridge
+          product: Matisse Device 24: Function 7
+          vendor: Advanced Micro Devices, Inc. [AMD]
+          physical id: 10f
+          bus info: pci@0000:00:18.7
+          version: 00
+          width: 32 bits
+          clock: 33MHz
+     *-scsi:0
+          physical id: 1
+          logical name: scsi2
+          capabilities: emulated
+        *-disk
+             description: ATA Disk
+             product: KINGSTON SA400S3
+             physical id: 0.0.0
+             bus info: scsi@2:0.0.0
+             logical name: /dev/sda
+             version: B1D1
+             serial: 50026B7782A80FC5
+             size: 447GiB (480GB)
+             capabilities: gpt-1.00 partitioned partitioned:gpt
+             configuration: ansiversion=5 guid=934e5e2b-2fac-4e40-afdb-7ffe29d50d95 logicalsectorsize=512 sectorsize=512
+           *-volume
+                description: EXT4 volume
+                vendor: Linux
+                physical id: 1
+                bus info: scsi@2:0.0.0,1
+                logical name: /dev/sda1
+                logical name: /home/frosteyes/Echo
+                version: 1.0
+                serial: b0aecac2-9652-4d5f-b3c2-54f7814cef2c
+                size: 447GiB
+                capacity: 447GiB
+                capabilities: journaled extended_attributes large_files huge_files dir_nlink recover 64bit extents ext4 ext2 initialized
+                configuration: created=2019-11-27 22:08:55 filesystem=ext4 lastmountpoint=/home/frosteyes/Echo modified=2021-05-03 12:42:19 mount.fstype=ext4 mount.options=rw,noatime mounted=2021-05-03 12:42:19 name=Linux filesystem state=mounted
+     *-scsi:1
+          physical id: 2
+          logical name: scsi3
+          capabilities: emulated
+        *-disk
+             description: ATA Disk
+             product: Samsung SSD 840
+             physical id: 0.0.0
+             bus info: scsi@3:0.0.0
+             logical name: /dev/sdb
+             version: BB6Q
+             serial: S1DHNSAF404404F
+             size: 465GiB (500GB)
+             capabilities: gpt-1.00 partitioned partitioned:gpt
+             configuration: ansiversion=5 guid=7e858452-3dc7-46ad-84c2-b97ddcc2a19b logicalsectorsize=512 sectorsize=512
+           *-volume
+                description: Windows NTFS volume
+                vendor: Windows
+                physical id: 1
+                bus info: scsi@3:0.0.0,1
+                logical name: /dev/sdb1
+                version: 3.1
+                serial: d0855811-8e12-d54f-989d-69219db61874
+                size: 465GiB
+                capacity: 465GiB
+                capabilities: ntfs initialized
+                configuration: clustersize=4096 created=2020-12-29 18:31:03 filesystem=ntfs name=Basic data partition state=clean
+     *-scsi:2
+          physical id: 3
+          logical name: scsi8
+          capabilities: emulated
+        *-disk
+             description: ATA Disk
+             product: CT2000MX500SSD1
+             physical id: 0.0.0
+             bus info: scsi@8:0.0.0
+             logical name: /dev/sdc
+             version: 033
+             serial: mebdD6-Grhs-FXhO-Xmyo-jcJP-x3pb-ZI1TMF
+             size: 1863GiB
+             capacity: 1863GiB
+             capabilities: lvm2
+             configuration: ansiversion=5 logicalsectorsize=512 sectorsize=4096
+     *-scsi:3
+          physical id: 4
+          logical name: scsi9
+          capabilities: emulated
+        *-disk
+             description: ATA Disk
+             product: CT2000MX500SSD1
+             physical id: 0.0.0
+             bus info: scsi@9:0.0.0
+             logical name: /dev/sdd
+             version: 033
+             serial: TOHCzZ-2lh3-6rtf-nPgz-9fOy-mlI5-XqMeiB
+             size: 1863GiB
+             capacity: 1863GiB
+             capabilities: lvm2
+             configuration: ansiversion=5 logicalsectorsize=512 sectorsize=4096
+  *-network:0 DISABLED
+       description: Ethernet interface
+       physical id: 1
+       logical name: dummy0
+       serial: 6a:30:45:6a:c6:9e
+       capabilities: ethernet physical
+       configuration: broadcast=yes driver=dummy driverversion=5.10.27-gentoo-FrostEyes
+  *-network:1
+       description: Ethernet interface
+       physical id: 2
+       logical name: br-dbf5911d131d
+       serial: 02:42:9b:b6:9b:ed
+       capabilities: ethernet physical
+       configuration: autonegotiation=off broadcast=yes driver=bridge driverversion=2.3 firmware=N/A ip=172.18.0.1 link=no multicast=yes
+  *-network:2
+       description: Ethernet interface
+       physical id: 3
+       logical name: docker0
+       serial: 02:42:4c:51:04:13
+       capabilities: ethernet physical
+       configuration: autonegotiation=off broadcast=yes driver=bridge driverversion=2.3 firmware=N/A ip=172.17.0.1 link=no multicast=yes


### PR DESCRIPTION
This is created to be able to compare the Corsair MP600 (PCIe 4.0 NVMe)
to tmpfs. Notice the ext4 filesystem on the MP600 is not optimized.

The NVMe runs in a Ubuntu 18.04 docker with

docker container run -t -i --rm --privileged \
 --device /dev/net/tun:/dev/net/tun \
 -h p1_yocto2020.3 \
 -v /home/frosteyes/Desktop/oe-test/:/home/yocto/oe-test \
 --name yocto yocto-ubuntu-18.04-dev

The tmpfs version is build with the same docker image but uses 80GB for
tmp folder

docker container run -t -i --rm --privileged \
 --device /dev/net/tun:/dev/net/tun -h p1_yocto2020.3 \
 -v /home/frosteyes/Desktop/oe-test/:/home/yocto/oe-test \
 --tmpfs /home/yocto/oe-test/test-oe-build-time/poky/build/tmp:rw,suid,dev,exec,size=80G \
 --name yocto yocto-ubuntu-18.04-dev

Signed-off-by: Claus Stovgaard <claus.stovgaard@gmail.com>